### PR TITLE
Feat: i18n

### DIFF
--- a/.changeset/tame-bottles-tap.md
+++ b/.changeset/tame-bottles-tap.md
@@ -1,0 +1,5 @@
+---
+'@croffledev/croffle-cli': patch
+---
+
+update deps

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
     "temporal-polyfill": "^1.0.2",
     "tw-animate-css": "^1.4.0",
     "vue": "^3.5.40",
+    "vue-i18n": "^11.4.8",
     "vue-router": "^5.2.0",
     "vue-sonner": "^2.0.9"
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -73,14 +73,14 @@
     "autoprefixer": "^10.5.4",
     "cross-env": "^10.1.0",
     "drizzle-kit": "^0.31.10",
-    "electron": "^43.2.0",
+    "electron": "^43.4.0",
     "electron-builder": "26.15.3",
     "electron-vite": "^5.0.0",
-    "esbuild": "^0.28.1",
-    "postcss": "^8.5.25",
+    "esbuild": "^0.28.2",
+    "postcss": "^8.5.26",
     "tailwindcss": "^4.3.3",
     "typescript": "6.0.3",
-    "vite": "^8.2.0",
+    "vite": "^8.2.1",
     "vue-tsc": "^3.3.9"
   }
 }

--- a/apps/desktop/src/common/recurrence.ts
+++ b/apps/desktop/src/common/recurrence.ts
@@ -38,26 +38,18 @@ export type RecurrenceFormState = {
   rawRule: string;
 };
 
-export const RECURRENCE_PRESET_OPTIONS: { value: RecurrencePreset; label: string }[] = [
-  { value: 'none', label: '반복 안 함' },
-  { value: 'daily', label: '매일' },
-  { value: 'weekdays', label: '평일 (월–금)' },
-  { value: 'weekly', label: '매주' },
-  { value: 'monthly', label: '매월' },
-  { value: 'every-n-days', label: 'N일마다' },
-  { value: 'every-n-weeks', label: 'N주마다' },
-  { value: 'custom', label: '사용자 지정' },
+export const RECURRENCE_PRESET_OPTIONS: RecurrencePreset[] = [
+  'none',
+  'daily',
+  'weekdays',
+  'weekly',
+  'monthly',
+  'every-n-days',
+  'every-n-weeks',
+  'custom',
 ];
 
-export const WEEKDAY_OPTIONS: { value: WeekdayCode; label: string }[] = [
-  { value: 'MO', label: '월' },
-  { value: 'TU', label: '화' },
-  { value: 'WE', label: '수' },
-  { value: 'TH', label: '목' },
-  { value: 'FR', label: '금' },
-  { value: 'SA', label: '토' },
-  { value: 'SU', label: '일' },
-];
+export const WEEKDAY_OPTIONS: WeekdayCode[] = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
 
 export function createDefaultRecurrenceFormState(): RecurrenceFormState {
   return {

--- a/apps/desktop/src/main/window/window-service.ts
+++ b/apps/desktop/src/main/window/window-service.ts
@@ -97,9 +97,9 @@ class WindowService {
       this.tray.setToolTip('CROFFLE');
 
       const contextMenu = Menu.buildFromTemplate([
-        { label: '열기', click: () => this.showWindow() },
+        { label: 'Open Window', click: () => this.showWindow() },
         { type: 'separator' },
-        { label: '종료', click: () => this.exitApp() },
+        { label: 'Exit App', click: () => this.exitApp() },
       ]);
 
       this.tray.setContextMenu(contextMenu);

--- a/apps/desktop/src/renderer/src/app.vue
+++ b/apps/desktop/src/renderer/src/app.vue
@@ -14,6 +14,7 @@
   import { Toaster } from '@/components/ui/sonner';
   import { translateOrRaw } from '@/i18n';
 
+  import ConfirmModal from './components/confirm-modal.vue';
   import LeftSidebar from './components/left-sidebar.vue';
   import RightSidebar from './components/right-sidebar.vue';
   import ScheduleModal from './components/schedule-modal.vue';
@@ -343,6 +344,7 @@
         </SidebarInset>
         <RightSidebar />
         <ScheduleModal />
+        <ConfirmModal />
       </SidebarProvider>
     </div>
 

--- a/apps/desktop/src/renderer/src/app.vue
+++ b/apps/desktop/src/renderer/src/app.vue
@@ -12,6 +12,7 @@
   import { Icon } from '@/components/ui/icon';
   import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
   import { Toaster } from '@/components/ui/sonner';
+  import { translateOrRaw } from '@/i18n';
 
   import LeftSidebar from './components/left-sidebar.vue';
   import RightSidebar from './components/right-sidebar.vue';
@@ -332,11 +333,11 @@
                 :disabled="item.disabled"
                 @click="item.action(contextMenuStore.activeElement)"
               >
-                {{ item.label }}
+                {{ translateOrRaw(item.label) }}
               </ContextMenuItem>
             </ContextMenuContent>
             <ContextMenuContent v-else>
-              <ContextMenuItem disabled>등록된 동작이 없습니다.</ContextMenuItem>
+              <ContextMenuItem disabled>{{ $t('contextMenu.empty') }}</ContextMenuItem>
             </ContextMenuContent>
           </ContextMenu>
         </SidebarInset>

--- a/apps/desktop/src/renderer/src/components/calendar.vue
+++ b/apps/desktop/src/renderer/src/components/calendar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { AppEventType } from '@croffledev/common';
   import type { CalendarOptions } from '@fullcalendar/core';
+  import koLocale from '@fullcalendar/core/locales/ko';
   import dayGridPlugin from '@fullcalendar/daygrid';
   import interactionPlugin from '@fullcalendar/interaction';
   import multiMonthPlugin from '@fullcalendar/multimonth';
@@ -150,7 +151,8 @@
 
       windowResizeDelay: 0,
       handleWindowResize: false,
-      locale: lang ? languageToLocale(lang) : 'ko',
+      locale: lang ? languageToLocale(lang) : 'en',
+      locales: [koLocale],
       firstDay: cal ? weekStartDayToFirstDay(cal.weekStartDay) : 0,
       weekNumbers: cal?.showWeekNumbers ?? false,
       weekNumberFormat: { week: 'narrow' },
@@ -179,7 +181,7 @@
     }
 
     const patch: Partial<CalendarOptions> = {
-      locale: lang ? languageToLocale(lang) : 'ko',
+      locale: lang ? languageToLocale(lang) : 'en',
       firstDay: weekStartDayToFirstDay(cal.weekStartDay),
       weekNumbers: cal.showWeekNumbers,
       eventTimeFormat: {

--- a/apps/desktop/src/renderer/src/components/confirm-modal.vue
+++ b/apps/desktop/src/renderer/src/components/confirm-modal.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { useI18n } from 'vue-i18n';
+
+  import { Button } from '@/components/ui/button';
+  import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+  } from '@/components/ui/dialog';
+  import { useUiStore } from '@/stores/ui-store';
+
+  const { t } = useI18n();
+  const uiStore = useUiStore();
+  const {
+    isConfirmModalOpen,
+    confirmTitle,
+    confirmDescription,
+    confirmConfirmLabel,
+    confirmCancelLabel,
+    confirmVariant,
+  } = storeToRefs(uiStore);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      uiStore.resolveConfirm(false);
+    }
+  };
+</script>
+
+<template>
+  <Dialog :open="isConfirmModalOpen" @update:open="handleOpenChange">
+    <DialogContent class="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{{ confirmTitle }}</DialogTitle>
+        <DialogDescription>{{ confirmDescription }}</DialogDescription>
+      </DialogHeader>
+      <DialogFooter class="gap-2">
+        <Button variant="outline" @click="uiStore.resolveConfirm(false)">
+          {{ confirmCancelLabel || t('common.cancel') }}
+        </Button>
+        <Button :variant="confirmVariant" @click="uiStore.resolveConfirm(true)">
+          {{ confirmConfirmLabel || t('common.delete') }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/desktop/src/renderer/src/components/help-modal.vue
+++ b/apps/desktop/src/renderer/src/components/help-modal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { ref, computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
 
   import {
     Dialog,
@@ -10,70 +11,48 @@
   } from '@/components/ui/dialog';
   import { Icon } from '@/components/ui/icon';
 
-  // Props 및 Emit 정의
-
   defineProps<{ open: boolean }>();
 
   const emit = defineEmits(['update:open']);
+  const { t } = useI18n();
 
   const currentStep = ref(0);
 
-  // 튜토리얼 데이터 정의
-
-  const steps = [
+  const steps = computed(() => [
     {
-      title: '환영합니다!',
-
-      description: '크로플(CROFFLE)에 오신 것을 환영해요.',
-
-      content: '왼쪽 메뉴를 통해 오늘 할 일과\n전체 달력을 자유롭게 오갈 수 있습니다.',
-
+      title: t('help.welcome.title'),
+      description: t('help.welcome.description'),
+      content: t('help.welcome.content'),
       icon: 'lucide:layout',
     },
-
     {
-      title: '할 일 추가하기',
-
-      description: '클릭 한 번으로 일정을 등록하세요.',
-
-      content:
-        '달력의 날짜를 클릭하면 즉시 할 일을 적을 수 있습니다.\n드래그해서 날짜를 옮기는 것도 가능해요!',
-
+      title: t('help.addTodo.title'),
+      description: t('help.addTodo.description'),
+      content: t('help.addTodo.content'),
       icon: 'lucide:calendar',
     },
-
     {
-      title: '나만의 테마 설정',
-
-      description: '취향에 맞는 색상으로 꾸며보세요.',
-
-      content:
-        '설정 메뉴에서 크로플의 메인 색상을 변경하여\n본인만의 작업 환경을 만들 수 있습니다.',
-
+      title: t('help.theme.title'),
+      description: t('help.theme.description'),
+      content: t('help.theme.content'),
       icon: 'lucide:palette',
     },
-
     {
-      title: '준비 완료!',
-
-      description: '이제 모든 준비가 끝났습니다.',
-
-      content: '지금 바로 첫 번째 할 일을 등록하고\n크로플과 함께 멋진 하루를 계획해 보세요!',
-
+      title: t('help.ready.title'),
+      description: t('help.ready.description'),
+      content: t('help.ready.content'),
       icon: 'lucide:party-popper',
     },
-  ];
+  ]);
 
-  const totalSteps = steps.length;
+  const totalSteps = computed(() => steps.value.length);
 
   const currentStepData = computed(() => {
-    return steps[currentStep.value] || steps[0];
+    return steps.value[currentStep.value] || steps.value[0];
   });
 
-  // 로직 함수
-
   const nextStep = () => {
-    if (currentStep.value < totalSteps - 1) {
+    if (currentStep.value < totalSteps.value - 1) {
       currentStep.value++;
     } else {
       handleClose();
@@ -139,7 +118,7 @@
           >
             <Icon icon="lucide:chevron-left" class="h-4 w-4" />
 
-            이전
+            {{ $t('help.prev') }}
           </button>
 
           <div v-else></div>
@@ -148,7 +127,7 @@
             class="bg-croffle-primary hover:bg-opacity-90 hover:bg-croffle-hover flex items-center gap-2 rounded-lg px-6 py-2.5 text-sm font-bold text-white shadow-md transition-all"
             @click="nextStep"
           >
-            {{ currentStep === totalSteps - 1 ? '확인' : '다음' }}
+            {{ currentStep === totalSteps - 1 ? $t('help.done') : $t('help.next') }}
 
             <Icon v-if="currentStep < totalSteps - 1" icon="lucide:chevron-right" class="h-4 w-4" />
           </button>

--- a/apps/desktop/src/renderer/src/components/left-sidebar.vue
+++ b/apps/desktop/src/renderer/src/components/left-sidebar.vue
@@ -18,6 +18,7 @@
     SidebarGroupContent,
   } from '@/components/ui/sidebar';
   import { DEFAULT_MENU_ITEMS } from '@/data/default-menus';
+  import { translateOrRaw } from '@/i18n';
   import { useUiStore } from '@/stores/ui-store';
   import { useViewStore } from '@/stores/view-store';
 
@@ -84,7 +85,7 @@
             >CROFFLE</span
           >
 
-          <span class="text-croffle-text text-xs leading-none">할일 달력</span>
+          <span class="text-croffle-text text-xs leading-none">{{ $t('sidebar.tagline') }}</span>
         </div>
       </div>
     </SidebarHeader>
@@ -93,7 +94,7 @@
       v-if="leftSidebarOpen"
       class="bg-croffle-sidebar text-croffle-text w-full pt-3 pr-0 pb-2 pl-4 text-left text-xs font-semibold tracking-wider uppercase"
     >
-      메인 메뉴
+      {{ $t('sidebar.mainMenu') }}
     </div>
 
     <SidebarContent class="bg-croffle-sidebar">
@@ -110,7 +111,7 @@
                   { 'bg-croffle-primary hover:bg-croffle-primary': item.active },
                   leftSidebarOpen ? 'mr-2 ml-0' : 'mx-0 justify-center',
                 ]"
-                :tooltip="item.title"
+                :tooltip="translateOrRaw(item.title)"
               >
                 <router-link
                   :to="item.url"
@@ -135,14 +136,14 @@
                       class="text-croffle-text text-sm leading-tight font-medium"
                       :class="{ 'text-white': item.active }"
                     >
-                      {{ item.title }}
+                      {{ translateOrRaw(item.title) }}
                     </span>
 
                     <span
                       class="text-croffle-text text-xs leading-none"
                       :class="{ 'text-white/80': item.active }"
                     >
-                      {{ item.subtitle }}
+                      {{ translateOrRaw(item.subtitle) }}
                     </span>
                   </div>
                 </router-link>
@@ -158,7 +159,7 @@
         <SidebarMenuButton
           size="sm"
           class="hover:bg-croffle-hover flex aspect-square h-9 w-9 items-center justify-center border-none bg-transparent shadow-none ring-0 ring-offset-0 transition-colors outline-none [--sidebar-accent:transparent] focus:ring-0 focus-visible:ring-0"
-          tooltip="알림"
+          :tooltip="$t('sidebar.notifications')"
         >
           <Icon icon="lucide:bell" class="text-croffle-text h-5 w-5" />
         </SidebarMenuButton>
@@ -166,7 +167,7 @@
         <SidebarMenuButton
           size="sm"
           class="hover:bg-croffle-hover flex aspect-square h-9 w-9 items-center justify-center border-none bg-transparent shadow-none ring-0 ring-offset-0 transition-colors outline-none [--sidebar-accent:transparent] focus:ring-0 focus-visible:ring-0"
-          tooltip="설정"
+          :tooltip="$t('sidebar.settings')"
           @click="emit('open-settings')"
         >
           <Icon icon="lucide:settings" class="text-croffle-text h-5 w-5" />
@@ -175,7 +176,7 @@
         <SidebarMenuButton
           size="sm"
           class="hover:bg-croffle-hover flex aspect-square h-9 w-9 items-center justify-center border-none bg-transparent shadow-none ring-0 ring-offset-0 transition-colors outline-none [--sidebar-accent:transparent] focus:ring-0 focus-visible:ring-0"
-          tooltip="도움말"
+          :tooltip="$t('sidebar.help')"
           @click="isHelpModalOpen = true"
         >
           <Icon icon="lucide:circle-help" class="text-croffle-text h-5 w-5" />

--- a/apps/desktop/src/renderer/src/components/right-sidebar.vue
+++ b/apps/desktop/src/renderer/src/components/right-sidebar.vue
@@ -3,6 +3,7 @@
   import isBetween from 'dayjs/plugin/isBetween';
   import { storeToRefs } from 'pinia';
   import { computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
 
   import { Badge } from '@/components/ui/badge';
   import { Button } from '@/components/ui/button';
@@ -19,6 +20,7 @@
 
   const uiStore = useUiStore();
   const scheduleStore = useScheduleStore();
+  const { t } = useI18n();
 
   const { rightSidebarOpen, selectedDate } = storeToRefs(uiStore);
 
@@ -72,11 +74,11 @@
   function getPriorityText(priority: string) {
     switch (priority) {
       case 'low':
-        return '낮음';
+        return t('priority.low');
       case 'medium':
-        return '보통';
+        return t('priority.medium');
       case 'high':
-        return '높음';
+        return t('priority.high');
     }
   }
 
@@ -98,8 +100,12 @@
         <div
           class="space-y-1 overflow-hidden text-left transition-all duration-300 group-data-[collapsible=icon]:hidden"
         >
-          <h2 class="text-croffle-text-dark text-lg font-bold whitespace-nowrap">일정 관리</h2>
-          <p class="text-croffle-text text-xs whitespace-nowrap">오늘의 일정과 계획</p>
+          <h2 class="text-croffle-text-dark text-lg font-bold whitespace-nowrap">
+            {{ $t('rightSidebar.title') }}
+          </h2>
+          <p class="text-croffle-text text-xs whitespace-nowrap">
+            {{ $t('rightSidebar.subtitle') }}
+          </p>
         </div>
 
         <Button
@@ -126,7 +132,7 @@
             class="h-5 w-5 transition-all"
             :class="rightSidebarOpen ? 'mr-1' : ''"
           />
-          <span class="group-data-[collapsible=icon]:hidden">새 일정 추가</span>
+          <span class="group-data-[collapsible=icon]:hidden">{{ $t('rightSidebar.add') }}</span>
         </Button>
       </div>
       <div
@@ -138,7 +144,7 @@
           <CardHeader class="space-y-0 px-4 pt-0 pb-2">
             <CardTitle class="text-croffle-text-dark flex items-center gap-2 text-sm font-bold">
               <Icon icon="lucide:calendar" class="h-4 w-4" />
-              <span>오늘의 일정</span>
+              <span>{{ $t('rightSidebar.today') }}</span>
               <Badge
                 class="bg-croffle-sidebar text-croffle-text-dark ml-auto h-5 rounded-md px-1.5"
               >
@@ -150,7 +156,7 @@
             class="text-croffle-text flex min-h-25 justify-center text-sm"
             :class="selectedSchedules.length === 0 ? 'items-center' : 'items-start'"
           >
-            <span v-if="selectedSchedules.length === 0">오늘 일정이 없습니다</span>
+            <span v-if="selectedSchedules.length === 0">{{ $t('rightSidebar.emptyToday') }}</span>
             <div v-else class="mt-2 flex w-full flex-col gap-1">
               <div
                 v-for="schedule in selectedSchedules"
@@ -186,11 +192,11 @@
           <CardHeader class="space-y-0 px-4 pt-0 pb-2">
             <CardTitle class="text-croffle-text-dark flex items-center gap-2 text-sm font-bold">
               <Icon icon="lucide:clock" class="h-4 w-4" />
-              <span>다가오는 일정</span>
+              <span>{{ $t('rightSidebar.upcoming') }}</span>
             </CardTitle>
           </CardHeader>
           <CardContent class="text-croffle-text flex min-h-25 items-center justify-center text-sm">
-            다가오는 일정이 없습니다
+            {{ $t('rightSidebar.emptyUpcoming') }}
           </CardContent>
         </Card>
       </div>

--- a/apps/desktop/src/renderer/src/components/schedule-modal.vue
+++ b/apps/desktop/src/renderer/src/components/schedule-modal.vue
@@ -15,6 +15,7 @@
   import { CalendarDate, getLocalTimeZone } from '@internationalized/date';
   import { storeToRefs } from 'pinia';
   import { computed, reactive, ref, shallowRef, toRaw, watch } from 'vue';
+  import { useI18n } from 'vue-i18n';
   import { toast } from 'vue-sonner';
 
   import { Button } from '@/components/ui/button';
@@ -56,6 +57,7 @@
 
   const uiStore = useUiStore();
   const scheduleStore = useScheduleStore();
+  const { t, locale } = useI18n();
   const { isScheduleModalOpen, scheduleModalMode, selectedScheduleId } = storeToRefs(uiStore);
 
   const DEFAULT_START_TIME = '09:00';
@@ -78,10 +80,10 @@
 
   const formatCalendarDate = (calendarDate: CalendarDate | undefined) => {
     if (!calendarDate) {
-      return '날짜 선택';
+      return t('schedule.pickDate');
     }
     const jsDate = calendarDate.toDate(getLocalTimeZone());
-    return new Intl.DateTimeFormat('ko-KR', {
+    return new Intl.DateTimeFormat(locale.value === 'ko' ? 'ko-KR' : 'en-US', {
       month: 'long',
       day: 'numeric',
       weekday: 'short',
@@ -243,7 +245,7 @@
     }
 
     if (end < start) {
-      toast.error('종료 일시는 시작 일시보다 빠를 수 없습니다.');
+      toast.error(t('schedule.invalidRange'));
       return;
     }
 
@@ -262,7 +264,7 @@
     try {
       recurrenceRule = buildRRule(recurrence, start);
     } catch {
-      toast.error('반복 규칙을 만들 수 없습니다.');
+      toast.error(t('schedule.invalidRule'));
       return;
     }
 
@@ -291,7 +293,7 @@
 
       uiStore.closeScheduleModal();
     } catch (error) {
-      toast.error(`일정 저장 실패: ${JSON.stringify(error)}`);
+      toast.error(t('schedule.saveFailed', { error: JSON.stringify(error) }));
     }
   };
 
@@ -306,7 +308,7 @@
         uiStore.closeScheduleModal();
       }
     } catch (error) {
-      toast.error(`일정 삭제 실패: ${JSON.stringify(error)}`);
+      toast.error(t('schedule.deleteFailed', { error: JSON.stringify(error) }));
     }
   };
 
@@ -358,26 +360,37 @@
     recurrence.byWeekday = [...recurrence.byWeekday, day];
   };
 
-  const priorityOptions = [
+  const RECURRENCE_PRESET_KEYS: Record<RecurrencePreset, string> = {
+    none: 'recurrence.none',
+    daily: 'recurrence.daily',
+    weekdays: 'recurrence.weekdays',
+    weekly: 'recurrence.weekly',
+    monthly: 'recurrence.monthly',
+    'every-n-days': 'recurrence.everyNDays',
+    'every-n-weeks': 'recurrence.everyNWeeks',
+    custom: 'recurrence.custom',
+  };
+
+  const priorityOptions = computed(() => [
     {
       value: 'low' as const,
-      label: '낮음',
+      label: t('priority.low'),
       active: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700',
       iconClass: 'text-emerald-600',
     },
     {
       value: 'medium' as const,
-      label: '보통',
+      label: t('priority.medium'),
       active: 'border-amber-500/40 bg-amber-500/10 text-amber-700',
       iconClass: 'text-amber-600',
     },
     {
       value: 'high' as const,
-      label: '높음',
+      label: t('priority.high'),
       active: 'border-rose-500/40 bg-rose-500/10 text-rose-700',
       iconClass: 'text-rose-600',
     },
-  ];
+  ]);
 </script>
 
 <template>
@@ -406,13 +419,15 @@
           </div>
           <div class="min-w-0 space-y-1">
             <DialogTitle class="text-foreground text-lg font-semibold tracking-tight">
-              {{ scheduleModalMode === 'edit' ? '일정 수정' : '새 일정' }}
+              {{
+                scheduleModalMode === 'edit' ? $t('schedule.editTitle') : $t('schedule.createTitle')
+              }}
             </DialogTitle>
             <DialogDescription class="text-muted-foreground text-sm">
               {{
                 scheduleModalMode === 'edit'
-                  ? '선택한 일정의 내용을 변경합니다.'
-                  : '제목과 날짜만 있어도 바로 추가할 수 있어요.'
+                  ? $t('schedule.editDescription')
+                  : $t('schedule.createDescription')
               }}
             </DialogDescription>
           </div>
@@ -427,34 +442,34 @@
                 variant="label"
                 class="text-muted-foreground mb-0 text-xs tracking-wide uppercase"
               >
-                기본 정보
+                {{ $t('schedule.basics') }}
               </FieldLegend>
 
               <Field>
                 <FieldLabel for="schedule-title">
-                  제목 <span class="text-destructive">*</span>
+                  {{ $t('schedule.title') }} <span class="text-destructive">*</span>
                 </FieldLabel>
                 <Input
                   id="schedule-title"
                   v-model="form.title"
-                  placeholder="무엇을 할까요?"
+                  :placeholder="$t('schedule.titlePlaceholder')"
                   class="border-croffle-border focus-visible:ring-croffle-primary/30 h-10"
                 />
               </Field>
 
               <Field>
-                <FieldLabel for="schedule-description">설명</FieldLabel>
+                <FieldLabel for="schedule-description">{{ $t('schedule.description') }}</FieldLabel>
                 <Textarea
                   id="schedule-description"
                   v-model="form.description"
-                  placeholder="메모나 세부 내용을 남겨두세요"
+                  :placeholder="$t('schedule.descriptionPlaceholder')"
                   rows="3"
                   class="border-croffle-border focus-visible:ring-croffle-primary/30 min-h-20 resize-none"
                 />
               </Field>
 
               <Field>
-                <FieldLabel for="schedule-location">장소</FieldLabel>
+                <FieldLabel for="schedule-location">{{ $t('schedule.location') }}</FieldLabel>
                 <div class="relative">
                   <Icon
                     icon="lucide:map-pin"
@@ -463,7 +478,7 @@
                   <Input
                     id="schedule-location"
                     v-model="form.location"
-                    placeholder="장소 (선택)"
+                    :placeholder="$t('schedule.locationPlaceholder')"
                     class="border-croffle-border focus-visible:ring-croffle-primary/30 h-10 pl-9"
                   />
                 </div>
@@ -477,7 +492,7 @@
                 variant="label"
                 class="text-muted-foreground mb-0 text-xs tracking-wide uppercase"
               >
-                날짜와 시간
+                {{ $t('schedule.dateTime') }}
               </FieldLegend>
 
               <Field
@@ -486,10 +501,10 @@
               >
                 <div class="space-y-0.5">
                   <FieldLabel for="schedule-all-day" class="text-sm font-medium">
-                    {{ '하루 종일' }}
+                    {{ $t('schedule.allDay') }}
                   </FieldLabel>
                   <FieldDescription class="text-xs">
-                    {{ '끄면 시작·종료 시간을 설정할 수 있어요' }}
+                    {{ $t('schedule.allDayHint') }}
                   </FieldDescription>
                 </div>
                 <Switch
@@ -502,7 +517,9 @@
 
               <div class="grid grid-cols-2 gap-3">
                 <Field>
-                  <FieldLabel class="text-muted-foreground text-xs">시작일</FieldLabel>
+                  <FieldLabel class="text-muted-foreground text-xs">{{
+                    $t('schedule.startDate')
+                  }}</FieldLabel>
                   <Popover v-model:open="isStartCalendarOpen">
                     <PopoverTrigger as-child>
                       <Button
@@ -540,7 +557,9 @@
                 </Field>
 
                 <Field>
-                  <FieldLabel class="text-muted-foreground text-xs">종료일</FieldLabel>
+                  <FieldLabel class="text-muted-foreground text-xs">{{
+                    $t('schedule.endDate')
+                  }}</FieldLabel>
                   <Popover v-model:open="isEndCalendarOpen">
                     <PopoverTrigger as-child>
                       <Button
@@ -584,13 +603,13 @@
               >
                 <Field>
                   <FieldLabel for="schedule-start-time" class="text-muted-foreground text-xs">
-                    시작 시간
+                    {{ $t('schedule.startTime') }}
                   </FieldLabel>
                   <TimeField id="schedule-start-time" v-model="startTime" />
                 </Field>
                 <Field>
                   <FieldLabel for="schedule-end-time" class="text-muted-foreground text-xs">
-                    종료 시간
+                    {{ $t('schedule.endTime') }}
                   </FieldLabel>
                   <TimeField id="schedule-end-time" v-model="endTime" />
                 </Field>
@@ -604,15 +623,15 @@
                 variant="label"
                 class="text-muted-foreground mb-0 text-xs tracking-wide uppercase"
               >
-                옵션
+                {{ $t('schedule.options') }}
               </FieldLegend>
 
               <Field>
-                <FieldLabel>우선순위</FieldLabel>
+                <FieldLabel>{{ $t('schedule.priority') }}</FieldLabel>
                 <div
                   class="border-croffle-border bg-muted/20 grid grid-cols-3 gap-1 rounded-xl border p-1"
                   role="radiogroup"
-                  aria-label="우선순위"
+                  :aria-label="$t('schedule.priority')"
                 >
                   <button
                     v-for="option in priorityOptions"
@@ -634,7 +653,7 @@
               </Field>
 
               <Field>
-                <FieldLabel>색상</FieldLabel>
+                <FieldLabel>{{ $t('schedule.color') }}</FieldLabel>
                 <div class="flex flex-wrap items-center gap-2">
                   <button
                     v-for="color in COLOR_PRESETS"
@@ -647,50 +666,52 @@
                         : 'border-transparent'
                     "
                     :style="{ backgroundColor: color }"
-                    :aria-label="`색상 ${color}`"
+                    :aria-label="$t('schedule.colorAria', { color })"
                     @click="form.colorLabel = color"
                   />
                   <label
                     class="border-croffle-border hover:bg-muted/50 relative flex size-8 cursor-pointer items-center justify-center overflow-hidden rounded-full border border-dashed"
-                    title="직접 선택"
+                    :title="$t('schedule.customColor')"
                   >
                     <Icon icon="lucide:palette" class="text-muted-foreground size-3.5" />
                     <input
                       v-model="form.colorLabel"
                       type="color"
                       class="absolute inset-0 cursor-pointer opacity-0"
-                      aria-label="사용자 지정 색상"
+                      :aria-label="$t('schedule.customColorAria')"
                     />
                   </label>
                 </div>
               </Field>
 
               <Field>
-                <FieldLabel for="schedule-recurrence">반복</FieldLabel>
+                <FieldLabel for="schedule-recurrence">{{ $t('schedule.recurrence') }}</FieldLabel>
                 <Select
                   :model-value="recurrence.preset"
                   @update:model-value="onRecurrencePresetChange"
                 >
                   <SelectTrigger id="schedule-recurrence" class="border-croffle-border h-10 w-full">
-                    <SelectValue placeholder="반복 주기" />
+                    <SelectValue :placeholder="$t('schedule.recurrencePlaceholder')" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem
-                      v-for="option in RECURRENCE_PRESET_OPTIONS"
-                      :key="option.value"
-                      :value="option.value"
+                      v-for="preset in RECURRENCE_PRESET_OPTIONS"
+                      :key="preset"
+                      :value="preset"
                     >
-                      {{ option.label }}
+                      {{ $t(RECURRENCE_PRESET_KEYS[preset]) }}
                     </SelectItem>
                   </SelectContent>
                 </Select>
                 <FieldDescription>
-                  캘린더에는 반복 일정이 자동으로 펼쳐져 표시됩니다.
+                  {{ $t('schedule.recurrenceHint') }}
                 </FieldDescription>
               </Field>
 
               <Field v-if="showInterval">
-                <FieldLabel for="schedule-recurrence-interval">간격</FieldLabel>
+                <FieldLabel for="schedule-recurrence-interval">{{
+                  $t('schedule.interval')
+                }}</FieldLabel>
                 <div class="flex items-center gap-2">
                   <Input
                     id="schedule-recurrence-interval"
@@ -700,35 +721,41 @@
                     class="border-croffle-border h-10 w-24"
                   />
                   <span class="text-muted-foreground text-sm">
-                    {{ recurrence.preset === 'every-n-weeks' ? '주마다' : '일마다' }}
+                    {{
+                      recurrence.preset === 'every-n-weeks'
+                        ? $t('schedule.everyWeeks')
+                        : $t('schedule.everyDays')
+                    }}
                   </span>
                 </div>
               </Field>
 
               <Field v-if="showWeekdays">
-                <FieldLabel>요일</FieldLabel>
+                <FieldLabel>{{ $t('schedule.weekdays') }}</FieldLabel>
                 <div class="flex flex-wrap gap-1.5">
                   <button
                     v-for="day in WEEKDAY_OPTIONS"
-                    :key="day.value"
+                    :key="day"
                     type="button"
                     class="h-8 min-w-8 rounded-md border px-2 text-xs font-medium transition-colors"
                     :class="
-                      recurrence.byWeekday.includes(day.value)
+                      recurrence.byWeekday.includes(day)
                         ? 'border-croffle-primary bg-croffle-primary/10 text-croffle-primary'
                         : 'border-croffle-border text-muted-foreground hover:bg-muted/50'
                     "
                     :disabled="!weekdaysEditable"
-                    @click="toggleWeekday(day.value)"
+                    @click="toggleWeekday(day)"
                   >
-                    {{ day.label }}
+                    {{ $t(`recurrence.weekday.${day}`) }}
                   </button>
                 </div>
               </Field>
 
               <template v-if="recurrence.preset !== 'none'">
                 <Field>
-                  <FieldLabel for="schedule-recurrence-end">반복 종료</FieldLabel>
+                  <FieldLabel for="schedule-recurrence-end">{{
+                    $t('schedule.recurrenceEnd')
+                  }}</FieldLabel>
                   <Select
                     :model-value="recurrence.endMode"
                     @update:model-value="onRecurrenceEndModeChange"
@@ -737,18 +764,18 @@
                       id="schedule-recurrence-end"
                       class="border-croffle-border h-10 w-full"
                     >
-                      <SelectValue placeholder="종료 조건" />
+                      <SelectValue :placeholder="$t('schedule.endConditionPlaceholder')" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="never">종료 없음</SelectItem>
-                      <SelectItem value="until">날짜까지</SelectItem>
-                      <SelectItem value="count">횟수</SelectItem>
+                      <SelectItem value="never">{{ $t('schedule.endNever') }}</SelectItem>
+                      <SelectItem value="until">{{ $t('schedule.endUntil') }}</SelectItem>
+                      <SelectItem value="count">{{ $t('schedule.endCount') }}</SelectItem>
                     </SelectContent>
                   </Select>
                 </Field>
 
                 <Field v-if="recurrence.endMode === 'until'">
-                  <FieldLabel>종료일</FieldLabel>
+                  <FieldLabel>{{ $t('schedule.untilDate') }}</FieldLabel>
                   <Popover v-model:open="isUntilCalendarOpen">
                     <PopoverTrigger as-child>
                       <Button
@@ -786,7 +813,9 @@
                 </Field>
 
                 <Field v-if="recurrence.endMode === 'count'">
-                  <FieldLabel for="schedule-recurrence-count">횟수</FieldLabel>
+                  <FieldLabel for="schedule-recurrence-count">{{
+                    $t('schedule.count')
+                  }}</FieldLabel>
                   <div class="flex items-center gap-2">
                     <Input
                       id="schedule-recurrence-count"
@@ -795,13 +824,17 @@
                       min="1"
                       class="border-croffle-border h-10 w-24"
                     />
-                    <span class="text-muted-foreground text-sm">회 반복</span>
+                    <span class="text-muted-foreground text-sm">{{
+                      $t('schedule.countSuffix')
+                    }}</span>
                   </div>
                 </Field>
               </template>
 
               <Field v-if="recurrence.preset === 'custom'">
-                <FieldLabel for="schedule-recurrence-raw">사용자 지정 RRULE</FieldLabel>
+                <FieldLabel for="schedule-recurrence-raw">{{
+                  $t('schedule.customRrule')
+                }}</FieldLabel>
                 <Input
                   id="schedule-recurrence-raw"
                   v-model="recurrence.rawRule"
@@ -826,7 +859,7 @@
             @click="handleDelete"
           >
             <Icon icon="lucide:trash-2" class="mr-1.5 size-4" />
-            삭제
+            {{ $t('common.delete') }}
           </Button>
         </div>
 
@@ -837,7 +870,7 @@
             class="border-croffle-border h-9"
             @click="uiStore.closeScheduleModal()"
           >
-            취소
+            {{ $t('common.cancel') }}
           </Button>
           <Button
             type="button"
@@ -849,7 +882,7 @@
               :icon="scheduleModalMode === 'edit' ? 'lucide:check' : 'lucide:plus'"
               class="mr-1.5 size-4"
             />
-            {{ scheduleModalMode === 'edit' ? '저장' : '추가' }}
+            {{ scheduleModalMode === 'edit' ? $t('common.save') : $t('common.add') }}
           </Button>
         </div>
       </DialogFooter>

--- a/apps/desktop/src/renderer/src/components/settings-modal.vue
+++ b/apps/desktop/src/renderer/src/components/settings-modal.vue
@@ -10,6 +10,7 @@
   import type { ConfigurationTabContribution, ExtensionInfo } from '@croffledev/common';
   import type { AppSettings } from '@croffledev/croffle-types';
   import { ref, onMounted, watch, computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
   import { toast } from 'vue-sonner';
 
   import ConfigSchemaForm from '@/components/settings/config-schema-form.vue';
@@ -56,6 +57,7 @@
 
   const settingsStore = useSettingsStore();
   const appSettingsStore = useAppSettingsStore();
+  const { t } = useI18n();
 
   const activeTab = ref<string>('general');
   const originalSettings = ref<AppSettings | null>(null);
@@ -88,12 +90,12 @@
 
   const UI_DRAFT_STORAGE_KEY = 'croffle:settings-ui-draft';
 
-  const builtinTabs = [
-    { id: 'general', label: '일반', icon: 'lucide:settings' },
-    { id: 'calendar', label: '캘린더', icon: 'lucide:calendar-days' },
-    { id: 'notifications', label: '알림', icon: 'lucide:bell' },
-    { id: 'extensions', label: '확장 관리', icon: 'lucide:puzzle' },
-  ] as const;
+  const builtinTabs = computed(() => [
+    { id: 'general', label: t('settings.tabs.general'), icon: 'lucide:settings' },
+    { id: 'calendar', label: t('settings.tabs.calendar'), icon: 'lucide:calendar-days' },
+    { id: 'notifications', label: t('settings.tabs.notifications'), icon: 'lucide:bell' },
+    { id: 'extensions', label: t('settings.tabs.extensions'), icon: 'lucide:puzzle' },
+  ]);
 
   const isBootEnabled = computed(() => settings.value?.general.startOnSystemBoot ?? false);
 
@@ -104,7 +106,7 @@
       icon: tab.icon ?? 'lucide:puzzle',
       extensionTab: tab,
     }));
-    return [...builtinTabs, ...extension];
+    return [...builtinTabs.value, ...extension];
   });
 
   const activeExtensionTab = computed(() => settingsStore.findExtensionTab(activeTab.value));
@@ -117,7 +119,7 @@
   });
 
   const activeTabLabel = computed(
-    () => allTabs.value.find((t) => t.id === activeTab.value)?.label ?? '설정',
+    () => allTabs.value.find((tab) => tab.id === activeTab.value)?.label ?? t('settings.title'),
   );
 
   // 깊은 복사 유틸
@@ -171,7 +173,7 @@
       }
       return JSON.parse(raw) as { notifications: NotificationDraft };
     } catch (error) {
-      toast.error(`UI draft 로드 실패: ${JSON.stringify(error)}`);
+      toast.error(t('settings.errors.uiDraftLoad', { error: JSON.stringify(error) }));
       return null;
     }
   };
@@ -183,7 +185,7 @@
       };
       localStorage.setItem(UI_DRAFT_STORAGE_KEY, JSON.stringify(payload));
     } catch (error) {
-      toast.error(`UI draft 저장 실패: ${JSON.stringify(error)}`);
+      toast.error(t('settings.errors.uiDraftSave', { error: JSON.stringify(error) }));
     }
   };
 
@@ -213,8 +215,8 @@
       syncUiDraft();
       await loadAllExtensionSettings();
     } catch (error) {
-      toast.error(`설정 로드 실패: ${JSON.stringify(error)}`);
-      loadError.value = '설정을 불러오지 못했습니다.';
+      toast.error(t('settings.errors.load', { error: JSON.stringify(error) }));
+      loadError.value = t('settings.loadFailed');
     } finally {
       isLoadingSettings.value = false;
     }
@@ -224,7 +226,7 @@
     try {
       installedPlugins.value = await croffle.extensions.info.getInstalled();
     } catch (err) {
-      toast.error(`확장 목록 로드 실패: ${JSON.stringify(err)}`);
+      toast.error(t('settings.errors.extensionsList', { error: JSON.stringify(err) }));
     }
   };
 
@@ -241,7 +243,7 @@
       await fetchInstalledPlugins();
       await extensionLoader.loadPluginById(plugin.id);
     } catch (err) {
-      toast.error(`Failed to install extension: ${JSON.stringify(err)}`);
+      toast.error(t('settings.errors.install', { error: JSON.stringify(err) }));
     } finally {
       isInstalling.value = false;
     }
@@ -256,7 +258,7 @@
         await extensionLoader.loadPluginById(result.id);
       }
     } catch (err) {
-      toast.error(`Failed to install local extension: ${JSON.stringify(err)}`);
+      toast.error(t('settings.errors.installLocal', { error: JSON.stringify(err) }));
     } finally {
       isInstalling.value = false;
     }
@@ -273,12 +275,12 @@
         await extensionLoader.unloadPlugin(plugin.id);
       }
     } catch (err) {
-      toast.error(`확장 토글 실패: ${JSON.stringify(err)}`);
+      toast.error(t('settings.errors.toggle', { error: JSON.stringify(err) }));
     }
   };
 
   const onUninstallExtension = async (plugin: ExtensionInfo) => {
-    if (!confirm(`'${plugin.name}' 확장을 삭제하시겠습니까?`)) {
+    if (!confirm(t('settings.extensions.uninstallConfirm', { name: plugin.name }))) {
       return;
     }
     try {
@@ -286,7 +288,7 @@
       await croffle.extensions.info.uninstall(plugin.id);
       await fetchInstalledPlugins();
     } catch (err) {
-      toast.error(`확장 삭제 실패: ${JSON.stringify(err)}`);
+      toast.error(t('settings.errors.uninstall', { error: JSON.stringify(err) }));
     }
   };
 
@@ -350,7 +352,7 @@
 
       emit('update:open', false);
     } catch (error) {
-      toast.error(`설정 저장 실패: ${JSON.stringify(error)}`);
+      toast.error(t('settings.errors.save', { error: JSON.stringify(error) }));
     }
   };
 
@@ -418,53 +420,55 @@
     settings.value.calendar.showWeekNumbers = asBool(v);
   };
 
-  const languageOptions = [
-    { value: AppSettingLanguage.KO, label: '한국어' },
-    { value: AppSettingLanguage.EN, label: 'English' },
-  ] as const;
+  const languageOptions = computed(() => [
+    { value: AppSettingLanguage.KO, label: t('language.ko') },
+    { value: AppSettingLanguage.EN, label: t('language.en') },
+  ]);
 
-  const themeOptions = [
-    { value: AppSettingTheme.LIGHT, label: '라이트' },
-    { value: AppSettingTheme.DARK, label: '다크' },
-    { value: AppSettingTheme.SYSTEM, label: '시스템 설정 따름' },
-  ] as const;
+  const themeOptions = computed(() => [
+    { value: AppSettingTheme.LIGHT, label: t('settings.general.themeLight') },
+    { value: AppSettingTheme.DARK, label: t('settings.general.themeDark') },
+    { value: AppSettingTheme.SYSTEM, label: t('settings.general.themeSystem') },
+  ]);
 
-  const startupBehaviorOptions = [
+  const startupBehaviorOptions = computed(() => [
     {
       value: AppSettingStartupBehavior.OPEN_LAST_SESSION,
-      label: '마지막에 열었던 화면',
+      label: t('settings.general.startupOpenLast'),
     },
     {
       value: AppSettingStartupBehavior.OPEN_NEW_WINDOW,
-      label: '캘린더 기본 화면',
+      label: t('settings.general.startupOpenCalendar'),
     },
     {
       value: AppSettingStartupBehavior.DO_NOTHING,
-      label: '열지 않음 (백그라운드)',
+      label: t('settings.general.startupDoNothing'),
     },
-  ] as const;
+  ]);
 
-  const calendarViewOptions = [
-    { value: CalendarView.DAY, label: '일' },
-    { value: CalendarView.WEEK, label: '주' },
-    { value: CalendarView.MONTH, label: '월' },
-    { value: CalendarView.YEAR, label: '연' },
-  ] as const;
+  const calendarViewOptions = computed(() => [
+    { value: CalendarView.DAY, label: t('settings.calendar.viewDay') },
+    { value: CalendarView.WEEK, label: t('settings.calendar.viewWeek') },
+    { value: CalendarView.MONTH, label: t('settings.calendar.viewMonth') },
+    { value: CalendarView.YEAR, label: t('settings.calendar.viewYear') },
+  ]);
 
-  const weekStartOptions = [
-    { value: CalendarWeekStartDay.SUNDAY, label: '일요일' },
-    { value: CalendarWeekStartDay.MONDAY, label: '월요일' },
-  ] as const;
+  const weekStartOptions = computed(() => [
+    { value: CalendarWeekStartDay.SUNDAY, label: t('settings.calendar.weekStartSunday') },
+    { value: CalendarWeekStartDay.MONDAY, label: t('settings.calendar.weekStartMonday') },
+  ]);
 
-  const timeFormatOptions = [
-    { value: CalendarTimeFormat.H12, label: '12시간 (AM/PM)' },
-    { value: CalendarTimeFormat.H24, label: '24시간' },
-  ] as const;
+  const timeFormatOptions = computed(() => [
+    { value: CalendarTimeFormat.H12, label: t('settings.calendar.timeFormat12h') },
+    { value: CalendarTimeFormat.H24, label: t('settings.calendar.timeFormat24h') },
+  ]);
 
-  const reminderMinuteOptions = [5, 10, 15, 30, 60].map((m) => ({
-    value: String(m),
-    label: `${m}분 전`,
-  }));
+  const reminderMinuteOptions = computed(() =>
+    [5, 10, 15, 30, 60].map((minutes) => ({
+      value: String(minutes),
+      label: t('settings.notifications.minutesBefore', { minutes }),
+    })),
+  );
 
   const onExtensionTabClick = async (tab: ConfigurationTabContribution) => {
     const compositeId = settingsStore.getTabCompositeId(tab);
@@ -487,14 +491,14 @@
       class="h-[90vh] max-h-235 w-[96vw] gap-0 overflow-hidden border-none p-0 shadow-2xl sm:w-[94vw] sm:max-w-none lg:w-[92vw]"
     >
       <DialogHeader class="sr-only">
-        <DialogTitle>설정</DialogTitle>
-        <DialogDescription>설정을 관리하고 업데이트하세요.</DialogDescription>
+        <DialogTitle>{{ $t('settings.title') }}</DialogTitle>
+        <DialogDescription>{{ $t('settings.description') }}</DialogDescription>
       </DialogHeader>
 
       <div class="bg-background text-foreground absolute inset-0 flex overflow-hidden">
         <!-- 좌측 탭 -->
         <div class="border-border bg-muted/20 w-60 shrink-0 overflow-y-auto border-r p-4">
-          <h2 class="text-foreground mb-6 px-2 text-xl font-bold">설정</h2>
+          <h2 class="text-foreground mb-6 px-2 text-xl font-bold">{{ $t('settings.title') }}</h2>
           <nav class="space-y-1">
             <button
               v-for="tab in allTabs"
@@ -529,32 +533,38 @@
 
           <div class="flex-1 overflow-y-auto px-6 pb-8 md:px-8">
             <div v-if="isLoadingSettings" class="w-full max-w-none space-y-3">
-              <p class="text-muted-foreground text-sm">설정을 불러오는 중...</p>
+              <p class="text-muted-foreground text-sm">{{ $t('settings.loading') }}</p>
             </div>
 
             <div v-else-if="loadError" class="w-full max-w-none space-y-3">
               <p class="text-destructive text-sm">{{ loadError }}</p>
               <div class="flex gap-2">
-                <Button type="button" variant="outline" @click="reloadSettings">다시 시도</Button>
-                <Button type="button" @click="emit('update:open', false)">닫기</Button>
+                <Button type="button" variant="outline" @click="reloadSettings">{{
+                  $t('common.retry')
+                }}</Button>
+                <Button type="button" @click="emit('update:open', false)">{{
+                  $t('common.close')
+                }}</Button>
               </div>
             </div>
 
             <div v-else-if="settings" class="w-full max-w-none space-y-8">
               <!-- 일반 -->
               <div v-if="activeTab === 'general'" class="space-y-8">
-                <p class="text-muted-foreground text-sm">앱 전역 기본 설정입니다.</p>
+                <p class="text-muted-foreground text-sm">{{ $t('settings.general.intro') }}</p>
 
                 <section class="space-y-4">
-                  <h4 class="text-base font-bold text-neutral-900">표시</h4>
+                  <h4 class="text-base font-bold text-neutral-900">
+                    {{ $t('settings.general.display') }}
+                  </h4>
 
                   <div class="space-y-2">
-                    <Label for="settings-language" class="text-foreground text-sm font-medium"
-                      >언어</Label
-                    >
+                    <Label for="settings-language" class="text-foreground text-sm font-medium">{{
+                      $t('settings.general.language')
+                    }}</Label>
                     <Select v-model="settings.general.language">
                       <SelectTrigger id="settings-language" class="w-full">
-                        <SelectValue placeholder="언어 선택" />
+                        <SelectValue :placeholder="$t('settings.general.languagePlaceholder')" />
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem
@@ -569,15 +579,15 @@
                   </div>
 
                   <div class="space-y-2">
-                    <Label for="settings-theme" class="text-foreground text-sm font-medium"
-                      >테마</Label
-                    >
+                    <Label for="settings-theme" class="text-foreground text-sm font-medium">{{
+                      $t('settings.general.theme')
+                    }}</Label>
                     <Select
                       :model-value="settings.general.theme"
                       @update:model-value="onThemeChange"
                     >
                       <SelectTrigger id="settings-theme" class="w-full">
-                        <SelectValue placeholder="테마 선택" />
+                        <SelectValue :placeholder="$t('settings.general.themePlaceholder')" />
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem
@@ -595,18 +605,22 @@
                 <Separator />
 
                 <section class="space-y-4">
-                  <h4 class="text-base font-bold text-neutral-900">업데이트</h4>
+                  <h4 class="text-base font-bold text-neutral-900">
+                    {{ $t('settings.general.updates') }}
+                  </h4>
                   <div class="flex items-center justify-between">
                     <div class="space-y-0.5">
-                      <Label class="text-foreground text-sm font-medium">자동 업데이트</Label>
+                      <Label class="text-foreground text-sm font-medium">{{
+                        $t('settings.general.autoUpdate')
+                      }}</Label>
                       <p class="text-muted-foreground text-xs">
-                        새 버전이 있으면 자동으로 확인하고 알립니다.
+                        {{ $t('settings.general.autoUpdateHint') }}
                       </p>
                     </div>
                     <Switch
                       :checked="settings.general.autoUpdate"
                       :model-value="settings.general.autoUpdate"
-                      aria-label="자동 업데이트"
+                      :aria-label="$t('settings.general.autoUpdate')"
                       @update:checked="(v: boolean) => setGeneralBool('autoUpdate', v)"
                       @update:model-value="(v: unknown) => setGeneralBool('autoUpdate', v)"
                     />
@@ -616,19 +630,23 @@
                 <Separator />
 
                 <section class="space-y-4">
-                  <h4 class="text-base font-bold text-neutral-900">시작 프로그램</h4>
+                  <h4 class="text-base font-bold text-neutral-900">
+                    {{ $t('settings.general.startup') }}
+                  </h4>
 
                   <div class="flex items-center justify-between">
                     <div class="space-y-0.5">
-                      <Label class="text-foreground text-sm font-medium">OS 시작 시 실행</Label>
+                      <Label class="text-foreground text-sm font-medium">{{
+                        $t('settings.general.startOnBoot')
+                      }}</Label>
                       <p class="text-muted-foreground text-xs">
-                        켜면 로그인 시 Croffle이 자동으로 실행됩니다.
+                        {{ $t('settings.general.startOnBootHint') }}
                       </p>
                     </div>
                     <Switch
                       :checked="settings.general.startOnSystemBoot"
                       :model-value="settings.general.startOnSystemBoot"
-                      aria-label="OS 시작 시 실행"
+                      :aria-label="$t('settings.general.startOnBoot')"
                       @update:checked="(v: boolean) => setGeneralBool('startOnSystemBoot', v)"
                       @update:model-value="(v: unknown) => setGeneralBool('startOnSystemBoot', v)"
                     />
@@ -644,11 +662,13 @@
                       <Label
                         for="settings-startup-behavior"
                         class="text-foreground text-sm font-medium"
-                        >시작 시 동작</Label
+                        >{{ $t('settings.general.startupBehavior') }}</Label
                       >
                       <Select v-model="settings.general.startupBehavior" :disabled="!isBootEnabled">
                         <SelectTrigger id="settings-startup-behavior" class="w-full">
-                          <SelectValue placeholder="시작 동작 선택" />
+                          <SelectValue
+                            :placeholder="$t('settings.general.startupBehaviorPlaceholder')"
+                          />
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem
@@ -661,22 +681,24 @@
                         </SelectContent>
                       </Select>
                       <p class="text-muted-foreground text-xs">
-                        OS 시작으로 앱이 실행될 때의 초기 화면 동작입니다.
+                        {{ $t('settings.general.startupBehaviorHint') }}
                       </p>
                     </div>
 
                     <div class="flex items-center justify-between">
                       <div class="space-y-0.5">
-                        <Label class="text-foreground text-sm font-medium">최소화로 시작</Label>
+                        <Label class="text-foreground text-sm font-medium">{{
+                          $t('settings.general.startMinimized')
+                        }}</Label>
                         <p class="text-muted-foreground text-xs">
-                          시작 시 창을 표시하지 않고 트레이에서 실행합니다.
+                          {{ $t('settings.general.startMinimizedHint') }}
                         </p>
                       </div>
                       <Switch
                         :checked="settings.general.startMinimized"
                         :model-value="settings.general.startMinimized"
                         :disabled="!isBootEnabled"
-                        aria-label="최소화로 시작"
+                        :aria-label="$t('settings.general.startMinimized')"
                         @update:checked="(v: boolean) => setGeneralBool('startMinimized', v)"
                         @update:model-value="(v: unknown) => setGeneralBool('startMinimized', v)"
                       />
@@ -687,15 +709,15 @@
 
               <!-- 캘린더 -->
               <div v-if="activeTab === 'calendar'" class="space-y-6">
-                <p class="text-muted-foreground text-sm">캘린더 표시 방식을 설정합니다.</p>
+                <p class="text-muted-foreground text-sm">{{ $t('settings.calendar.intro') }}</p>
 
                 <div class="space-y-2">
-                  <Label for="settings-default-view" class="text-foreground text-sm font-medium"
-                    >기본 뷰</Label
-                  >
+                  <Label for="settings-default-view" class="text-foreground text-sm font-medium">{{
+                    $t('settings.calendar.defaultView')
+                  }}</Label>
                   <Select v-model="settings.calendar.defaultView">
                     <SelectTrigger id="settings-default-view" class="w-full">
-                      <SelectValue placeholder="기본 뷰 선택" />
+                      <SelectValue :placeholder="$t('settings.calendar.defaultViewPlaceholder')" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem
@@ -710,12 +732,12 @@
                 </div>
 
                 <div class="space-y-2">
-                  <Label for="settings-week-start" class="text-foreground text-sm font-medium"
-                    >한 주의 시작 요일</Label
-                  >
+                  <Label for="settings-week-start" class="text-foreground text-sm font-medium">{{
+                    $t('settings.calendar.weekStart')
+                  }}</Label>
                   <Select v-model="settings.calendar.weekStartDay">
                     <SelectTrigger id="settings-week-start" class="w-full">
-                      <SelectValue placeholder="시작 요일" />
+                      <SelectValue :placeholder="$t('settings.calendar.weekStartPlaceholder')" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem
@@ -730,12 +752,12 @@
                 </div>
 
                 <div class="space-y-2">
-                  <Label for="settings-time-format" class="text-foreground text-sm font-medium"
-                    >시간 형식</Label
-                  >
+                  <Label for="settings-time-format" class="text-foreground text-sm font-medium">{{
+                    $t('settings.calendar.timeFormat')
+                  }}</Label>
                   <Select v-model="settings.calendar.timeFormat">
                     <SelectTrigger id="settings-time-format" class="w-full">
-                      <SelectValue placeholder="시간 형식" />
+                      <SelectValue :placeholder="$t('settings.calendar.timeFormatPlaceholder')" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem
@@ -751,13 +773,17 @@
 
                 <div class="flex items-center justify-between">
                   <div class="space-y-0.5">
-                    <Label class="text-foreground text-sm font-medium">주차 표시</Label>
-                    <p class="text-muted-foreground text-xs">캘린더에 주차 번호를 표시합니다.</p>
+                    <Label class="text-foreground text-sm font-medium">{{
+                      $t('settings.calendar.showWeekNumbers')
+                    }}</Label>
+                    <p class="text-muted-foreground text-xs">
+                      {{ $t('settings.calendar.showWeekNumbersHint') }}
+                    </p>
                   </div>
                   <Switch
                     :checked="settings.calendar.showWeekNumbers"
                     :model-value="settings.calendar.showWeekNumbers"
-                    aria-label="주차 표시"
+                    :aria-label="$t('settings.calendar.showWeekNumbers')"
                     @update:checked="onShowWeekNumbersSwitch"
                     @update:model-value="onShowWeekNumbersSwitch"
                   />
@@ -766,34 +792,42 @@
 
               <!-- 알림 -->
               <div v-if="activeTab === 'notifications'" class="space-y-6">
-                <p class="text-muted-foreground text-sm">일정 알림 설정입니다.</p>
+                <p class="text-muted-foreground text-sm">
+                  {{ $t('settings.notifications.intro') }}
+                </p>
 
                 <div class="flex items-center justify-between border-b border-neutral-100 py-2">
                   <div class="min-w-0 space-y-0.5">
-                    <Label class="text-sm font-semibold">알림 사용</Label>
+                    <Label class="text-sm font-semibold">{{
+                      $t('settings.notifications.enabled')
+                    }}</Label>
                     <p class="text-muted-foreground wrap-break-words text-xs">
-                      일정 알림을 받을지 설정합니다.
+                      {{ $t('settings.notifications.enabledHint') }}
                     </p>
                   </div>
                   <Switch
                     :checked="settings.notifications.enabled"
                     :model-value="settings.notifications.enabled"
-                    aria-label="알림 사용"
+                    :aria-label="$t('settings.notifications.enabled')"
                     @update:checked="onAppAlertSwitch"
                     @update:model-value="onAppAlertSwitch"
                   />
                 </div>
 
                 <div class="space-y-2">
-                  <Label for="settings-reminder-minutes" class="text-foreground text-sm font-medium"
-                    >기본 알림 시간</Label
+                  <Label
+                    for="settings-reminder-minutes"
+                    class="text-foreground text-sm font-medium"
+                    >{{ $t('settings.notifications.defaultTime') }}</Label
                   >
                   <Select
                     :model-value="String(settings.notifications.defaultReminderMinutes)"
                     @update:model-value="onReminderMinutesChange"
                   >
                     <SelectTrigger id="settings-reminder-minutes" class="w-full">
-                      <SelectValue placeholder="알림 시점" />
+                      <SelectValue
+                        :placeholder="$t('settings.notifications.defaultTimePlaceholder')"
+                      />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem
@@ -806,7 +840,7 @@
                     </SelectContent>
                   </Select>
                   <p class="text-muted-foreground text-xs">
-                    새 일정 생성 시 기본으로 적용되는 알림 시점입니다.
+                    {{ $t('settings.notifications.defaultTimeHint') }}
                   </p>
                 </div>
 
@@ -814,10 +848,12 @@
 
                 <section class="space-y-4 opacity-80">
                   <p class="text-muted-foreground text-xs">
-                    아래 항목은 추후 계정/알림 고도화용 UI입니다 (현재 AppSettings에 미포함).
+                    {{ $t('settings.notifications.comingSoon') }}
                   </p>
                   <div class="flex items-center justify-between py-2">
-                    <Label class="text-sm font-semibold">이메일 알림 (준비 중)</Label>
+                    <Label class="text-sm font-semibold">{{
+                      $t('settings.notifications.emailAlert')
+                    }}</Label>
                     <Switch
                       disabled
                       :checked="notificationDraft.emailAlert"
@@ -848,14 +884,16 @@
                         </SelectItem>
                       </SelectContent>
                     </Select>
-                    <span class="text-sm text-neutral-500">방해 금지 (준비 중)</span>
+                    <span class="text-sm text-neutral-500">{{
+                      $t('settings.notifications.dnd')
+                    }}</span>
                   </div>
                 </section>
               </div>
 
               <!-- 플러그인 관리 -->
               <div v-if="activeTab === 'extensions'" class="space-y-6">
-                <p class="text-muted-foreground text-sm">확장을 설치하고 관리합니다.</p>
+                <p class="text-muted-foreground text-sm">{{ $t('settings.extensions.intro') }}</p>
 
                 <!-- 설치 폼 -->
                 <div
@@ -865,7 +903,7 @@
                     class="mb-3 text-sm font-bold text-neutral-900 dark:text-neutral-100 flex items-center gap-2"
                   >
                     <Icon icon="lucide:github" class="h-4 w-4" />
-                    GitHub에서 설치
+                    {{ $t('settings.extensions.installFromGithub') }}
                   </h4>
                   <div class="flex items-center gap-3">
                     <input
@@ -887,7 +925,7 @@
                         class="h-4 w-4 animate-spin"
                       />
                       <Icon v-else icon="lucide:download" class="h-4 w-4" />
-                      설치
+                      {{ $t('settings.extensions.install') }}
                     </Button>
                   </div>
 
@@ -897,7 +935,7 @@
                     class="mb-3 text-sm font-bold text-neutral-900 dark:text-neutral-100 flex items-center gap-2"
                   >
                     <Icon icon="lucide:download" class="h-4 w-4" />
-                    로컬 Zip 파일로 설치
+                    {{ $t('settings.extensions.installFromZip') }}
                   </h4>
                   <div class="flex items-center gap-3">
                     <Button
@@ -912,7 +950,7 @@
                         class="h-4 w-4 animate-spin"
                       />
                       <Icon v-else icon="lucide:download" class="h-4 w-4" />
-                      파일 선택 및 설치
+                      {{ $t('settings.extensions.selectAndInstall') }}
                     </Button>
                   </div>
                 </div>
@@ -920,7 +958,7 @@
                 <!-- 확장 목록 -->
                 <div class="space-y-4">
                   <h4 class="text-base font-bold text-neutral-900 dark:text-neutral-100">
-                    설치된 확장
+                    {{ $t('settings.extensions.installed') }}
                   </h4>
 
                   <div
@@ -931,10 +969,10 @@
                       <Icon icon="lucide:puzzle" class="h-6 w-6 text-neutral-500" />
                     </div>
                     <p class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                      설치된 확장이 없습니다.
+                      {{ $t('settings.extensions.emptyTitle') }}
                     </p>
                     <p class="mt-1 text-xs text-neutral-500">
-                      위쪽 설치 폼에 GitHub URL을 입력하여 확장을 추가해보세요.
+                      {{ $t('settings.extensions.emptyHint') }}
                     </p>
                   </div>
 
@@ -974,7 +1012,7 @@
                         <div class="flex items-center gap-2">
                           <Switch
                             :model-value="plugin.enabled"
-                            aria-label="확장 활성화"
+                            :aria-label="$t('settings.extensions.enableAria')"
                             @update:model-value="
                               (v) => {
                                 plugin.enabled = v;
@@ -986,7 +1024,11 @@
                             class="text-xs font-medium"
                             :class="plugin.enabled ? 'text-[#A68A64]' : 'text-neutral-500'"
                           >
-                            {{ plugin.enabled ? '사용 중' : '사용 안 함' }}
+                            {{
+                              plugin.enabled
+                                ? $t('settings.extensions.enabled')
+                                : $t('settings.extensions.disabled')
+                            }}
                           </span>
                         </div>
                         <Button
@@ -997,7 +1039,7 @@
                           @click="onUninstallExtension(plugin)"
                         >
                           <Icon icon="lucide:trash-2" class="h-4 w-4" />
-                          <span class="sr-only">삭제</span>
+                          <span class="sr-only">{{ $t('common.delete') }}</span>
                         </Button>
                       </div>
                     </div>
@@ -1015,7 +1057,11 @@
               <!-- Extension: schema sections -->
               <div v-else-if="activeExtensionTab?.sections?.length" class="space-y-8">
                 <p v-if="activeExtensionTab.extensionName" class="text-muted-foreground text-sm">
-                  {{ activeExtensionTab.extensionName }} 확장 구성
+                  {{
+                    $t('settings.extensions.configHeading', {
+                      name: activeExtensionTab.extensionName,
+                    })
+                  }}
                 </p>
                 <ConfigSchemaForm
                   v-for="section in activeExtensionTab.sections"
@@ -1038,14 +1084,14 @@
               class="h-9 border-neutral-200 px-6 font-semibold"
               @click="handleCancel"
             >
-              취소
+              {{ $t('common.cancel') }}
             </Button>
             <Button
               type="button"
               class="h-9 border-none bg-[#A68A64] px-6 font-semibold text-white transition-colors hover:bg-[#8E7554]"
               @click="handleSave"
             >
-              저장
+              {{ $t('common.save') }}
             </Button>
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/components/ui/sonner/Sonner.vue
+++ b/apps/desktop/src/renderer/src/components/ui/sonner/Sonner.vue
@@ -6,13 +6,18 @@
   import type { ToasterProps } from 'vue-sonner';
   import { Toaster as Sonner } from 'vue-sonner';
 
+  import { useThemeStore } from '@/stores/theme-store';
+
   const props = defineProps<ToasterProps>();
+  const { currentTheme } = useThemeStore();
 </script>
 
 <template>
   <Sonner
-    class="toaster group pointer-events-auto"
     v-bind="props"
+    class="toaster group pointer-events-auto"
+    rich-colors
+    :theme="currentTheme"
     :style="{
       '--normal-bg': 'var(--popover)',
       '--normal-text': 'var(--popover-foreground)',

--- a/apps/desktop/src/renderer/src/components/ui/sonner/Sonner.vue
+++ b/apps/desktop/src/renderer/src/components/ui/sonner/Sonner.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+  // vue-sonner v2 no longer injects CSS — without this, the toaster is not
+  // position:fixed and occupies flex space (shrinking the main calendar area).
+  // oxlint-disable-next-line import/no-unassigned-import
+  import 'vue-sonner/style.css';
   import type { ToasterProps } from 'vue-sonner';
   import { Toaster as Sonner } from 'vue-sonner';
 
@@ -7,7 +11,7 @@
 
 <template>
   <Sonner
-    class="toaster group"
+    class="toaster group pointer-events-auto"
     v-bind="props"
     :style="{
       '--normal-bg': 'var(--popover)',

--- a/apps/desktop/src/renderer/src/components/update-modal.vue
+++ b/apps/desktop/src/renderer/src/components/update-modal.vue
@@ -21,10 +21,10 @@
   <Dialog :open="isModalOpen">
     <DialogContent>
       <DialogHeader>
-        <DialogTitle>{{ '새 버전이 있습니다.' }}</DialogTitle>
+        <DialogTitle>{{ $t('update.available') }}</DialogTitle>
       </DialogHeader>
       <DialogDescription>
-        {{ `v${updateInfo?.version} 버전으로 업데이트 할 수 있습니다.` }}
+        {{ $t('update.availableDescription', { version: updateInfo?.version }) }}
       </DialogDescription>
 
       <div
@@ -34,17 +34,17 @@
       />
 
       <div v-if="isDownloading">
-        <p>{{ `다운로드 중... (${Math.round(downloadProgress)}%)` }}</p>
+        <p>{{ $t('update.downloading', { percent: Math.round(downloadProgress) }) }}</p>
       </div>
 
       <DialogFooter class="gap-2">
         <Button variant="ghost" :disabled="isDownloading" @click="skipUpdate">{{
-          '이번 버전은 건너뛰기'
+          $t('update.skip')
         }}</Button>
         <Button variant="outline" :disabled="isDownloading" @click="downloadLater">{{
-          '다음 시작 시 적용'
+          $t('update.later')
         }}</Button>
-        <Button :disabled="isDownloading" @click="downloadNow">{{ '지금 업데이트' }}</Button>
+        <Button :disabled="isDownloading" @click="downloadNow">{{ $t('update.now') }}</Button>
       </DialogFooter>
     </DialogContent>
   </Dialog>

--- a/apps/desktop/src/renderer/src/data/default-context-menus.ts
+++ b/apps/desktop/src/renderer/src/data/default-context-menus.ts
@@ -93,10 +93,10 @@ export const defaultMenus: FeatureContextMenu[] = [
 
       try {
         const isSuccess = await useScheduleStore().removeScheduleById(eventId);
-        if (!isSuccess) {
-          toast.error(t('contextMenu.deleteFailed'));
-        } else {
+        if (isSuccess) {
           toast.success(t('contextMenu.deleteSuccess'));
+        } else {
+          toast.error(t('contextMenu.deleteFailed'));
         }
       } catch {
         toast.error(t('contextMenu.deleteError'));

--- a/apps/desktop/src/renderer/src/data/default-context-menus.ts
+++ b/apps/desktop/src/renderer/src/data/default-context-menus.ts
@@ -80,7 +80,13 @@ export const defaultMenus: FeatureContextMenu[] = [
         return;
       }
 
-      const confirmed = window.confirm(t('contextMenu.deleteConfirm'));
+      const confirmed = await useUiStore().openConfirm({
+        title: t('contextMenu.deleteSchedule'),
+        description: t('contextMenu.deleteConfirm'),
+        confirmLabel: t('common.delete'),
+        cancelLabel: t('common.cancel'),
+        confirmVariant: 'destructive',
+      });
       if (!confirmed) {
         return;
       }

--- a/apps/desktop/src/renderer/src/data/default-context-menus.ts
+++ b/apps/desktop/src/renderer/src/data/default-context-menus.ts
@@ -1,6 +1,7 @@
 import type { FeatureContextMenu } from '@croffledev/common';
 import { toast } from 'vue-sonner';
 
+import { i18n } from '@/i18n';
 import { useScheduleStore } from '@/stores/schedule-store';
 
 import { useUiStore } from '../stores/ui-store';
@@ -14,10 +15,14 @@ const getClickedDateFromTarget = (target: HTMLElement): string | null => {
   return dayCell ? dayCell.getAttribute('data-date') : null;
 };
 
+function t(key: string) {
+  return String(i18n.global.t(key));
+}
+
 export const defaultMenus: FeatureContextMenu[] = [
   {
     id: 'add-schedule',
-    label: '일정 추가',
+    label: 'contextMenu.addSchedule',
     action: (targetElement: HTMLElement | null) => {
       if (!targetElement) {
         return;
@@ -33,7 +38,7 @@ export const defaultMenus: FeatureContextMenu[] = [
   },
   {
     id: 'view-schedule',
-    label: '해당 일자 보기',
+    label: 'contextMenu.viewDay',
     action: (targetElement: HTMLElement | null) => {
       if (!targetElement) {
         return;
@@ -49,7 +54,7 @@ export const defaultMenus: FeatureContextMenu[] = [
   },
   {
     id: 'edit-schedule',
-    label: '일정 수정',
+    label: 'contextMenu.editSchedule',
     action: (targetElement: HTMLElement | null) => {
       if (!targetElement) {
         return;
@@ -65,7 +70,7 @@ export const defaultMenus: FeatureContextMenu[] = [
   },
   {
     id: 'delete-schedule',
-    label: '일정 삭제',
+    label: 'contextMenu.deleteSchedule',
     action: async (targetElement: HTMLElement | null) => {
       if (!targetElement) {
         return;
@@ -75,7 +80,7 @@ export const defaultMenus: FeatureContextMenu[] = [
         return;
       }
 
-      const confirmed = window.confirm('이 일정을 삭제하시겠습니까?');
+      const confirmed = window.confirm(t('contextMenu.deleteConfirm'));
       if (!confirmed) {
         return;
       }
@@ -83,12 +88,12 @@ export const defaultMenus: FeatureContextMenu[] = [
       try {
         const isSuccess = await useScheduleStore().removeScheduleById(eventId);
         if (!isSuccess) {
-          toast.error('일정 삭제에 실패했습니다. 다시 시도해주세요.');
+          toast.error(t('contextMenu.deleteFailed'));
         } else {
-          toast.success('일정이 삭제되었습니다.');
+          toast.success(t('contextMenu.deleteSuccess'));
         }
       } catch {
-        toast.error('일정 삭제 중 오류가 발생했습니다. 다시 시도해주세요.');
+        toast.error(t('contextMenu.deleteError'));
       }
     },
     condition: (target) => !!target?.closest('.fc-event'),

--- a/apps/desktop/src/renderer/src/data/default-menus.ts
+++ b/apps/desktop/src/renderer/src/data/default-menus.ts
@@ -3,8 +3,8 @@ import type { FeatureView } from '@croffledev/common';
 export const DEFAULT_MENU_ITEMS: FeatureView[] = [
   {
     id: 'calendar',
-    title: '캘린더',
-    subtitle: 'Calendar',
+    title: 'sidebar.calendar.title',
+    subtitle: 'sidebar.calendar.subtitle',
     icon: 'lucide:calendar-days',
     url: '/calendar',
     active: true,

--- a/apps/desktop/src/renderer/src/i18n/index.ts
+++ b/apps/desktop/src/renderer/src/i18n/index.ts
@@ -1,0 +1,19 @@
+import { createI18n } from 'vue-i18n';
+
+import en from './locales/en.json';
+import ko from './locales/ko.json';
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en, ko },
+});
+
+export function setI18nLocale(locale: string): void {
+  i18n.global.locale.value = locale === 'ko' ? 'ko' : 'en';
+}
+
+export function translateOrRaw(key: string): string {
+  return i18n.global.te(key) ? String(i18n.global.t(key)) : key;
+}

--- a/apps/desktop/src/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en.json
@@ -1,0 +1,253 @@
+{
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "close": "Close",
+    "delete": "Delete",
+    "retry": "Retry",
+    "add": "Add"
+  },
+  "language": {
+    "ko": "한국어",
+    "en": "English"
+  },
+  "priority": {
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High"
+  },
+  "settings": {
+    "title": "Settings",
+    "description": "Manage and update your settings.",
+    "tabs": {
+      "general": "General",
+      "calendar": "Calendar",
+      "notifications": "Notifications",
+      "extensions": "Extensions"
+    },
+    "loading": "Loading settings...",
+    "loadFailed": "Failed to load settings.",
+    "general": {
+      "intro": "App-wide defaults.",
+      "display": "Display",
+      "language": "Language",
+      "languagePlaceholder": "Select language",
+      "theme": "Theme",
+      "themePlaceholder": "Select theme",
+      "themeLight": "Light",
+      "themeDark": "Dark",
+      "themeSystem": "Match system",
+      "updates": "Updates",
+      "autoUpdate": "Automatic updates",
+      "autoUpdateHint": "Check for new versions and notify you automatically.",
+      "startup": "Startup",
+      "startOnBoot": "Launch at login",
+      "startOnBootHint": "Start Croffle automatically when you log in.",
+      "startupBehavior": "On launch",
+      "startupBehaviorPlaceholder": "Select startup behavior",
+      "startupOpenLast": "Last opened screen",
+      "startupOpenCalendar": "Calendar home",
+      "startupDoNothing": "Don't open (background)",
+      "startupBehaviorHint": "What to show when the app starts with the OS.",
+      "startMinimized": "Start minimized",
+      "startMinimizedHint": "Run in the tray without showing a window."
+    },
+    "calendar": {
+      "intro": "How the calendar is displayed.",
+      "defaultView": "Default view",
+      "defaultViewPlaceholder": "Select default view",
+      "viewDay": "Day",
+      "viewWeek": "Week",
+      "viewMonth": "Month",
+      "viewYear": "Year",
+      "weekStart": "First day of week",
+      "weekStartPlaceholder": "Select first day",
+      "weekStartSunday": "Sunday",
+      "weekStartMonday": "Monday",
+      "timeFormat": "Time format",
+      "timeFormatPlaceholder": "Select time format",
+      "timeFormat12h": "12-hour (AM/PM)",
+      "timeFormat24h": "24-hour",
+      "showWeekNumbers": "Week numbers",
+      "showWeekNumbersHint": "Show week numbers on the calendar."
+    },
+    "notifications": {
+      "intro": "Schedule notification settings.",
+      "enabled": "Enable notifications",
+      "enabledHint": "Choose whether to receive schedule reminders.",
+      "defaultTime": "Default reminder",
+      "defaultTimePlaceholder": "Select reminder time",
+      "minutesBefore": "{minutes} minutes before",
+      "defaultTimeHint": "Applied by default when you create a new schedule.",
+      "comingSoon": "The items below are for a future account/notification UI (not in AppSettings yet).",
+      "emailAlert": "Email notifications (coming soon)",
+      "dnd": "Do not disturb (coming soon)"
+    },
+    "extensions": {
+      "intro": "Install and manage extensions.",
+      "installFromGithub": "Install from GitHub",
+      "install": "Install",
+      "installFromZip": "Install from local zip",
+      "selectAndInstall": "Choose file and install",
+      "installed": "Installed extensions",
+      "emptyTitle": "No extensions installed.",
+      "emptyHint": "Enter a GitHub URL in the form above to add an extension.",
+      "enabled": "On",
+      "disabled": "Off",
+      "enableAria": "Enable extension",
+      "uninstallConfirm": "Uninstall '{name}'?",
+      "configHeading": "{name} configuration"
+    },
+    "errors": {
+      "uiDraftLoad": "Failed to load UI draft: {error}",
+      "uiDraftSave": "Failed to save UI draft: {error}",
+      "load": "Failed to load settings: {error}",
+      "extensionsList": "Failed to load extensions: {error}",
+      "install": "Failed to install extension: {error}",
+      "installLocal": "Failed to install local extension: {error}",
+      "toggle": "Failed to toggle extension: {error}",
+      "uninstall": "Failed to uninstall extension: {error}",
+      "save": "Failed to save settings: {error}"
+    }
+  },
+  "sidebar": {
+    "tagline": "Task calendar",
+    "mainMenu": "Main menu",
+    "notifications": "Notifications",
+    "settings": "Settings",
+    "help": "Help",
+    "calendar": {
+      "title": "Calendar",
+      "subtitle": "Calendar"
+    }
+  },
+  "rightSidebar": {
+    "title": "Schedules",
+    "subtitle": "Today's plans",
+    "add": "Add schedule",
+    "today": "Today",
+    "emptyToday": "No schedules today",
+    "upcoming": "Upcoming",
+    "emptyUpcoming": "No upcoming schedules"
+  },
+  "contextMenu": {
+    "addSchedule": "Add schedule",
+    "viewDay": "View this day",
+    "editSchedule": "Edit schedule",
+    "deleteSchedule": "Delete schedule",
+    "deleteConfirm": "Delete this schedule?",
+    "deleteFailed": "Failed to delete the schedule. Please try again.",
+    "deleteSuccess": "Schedule deleted.",
+    "deleteError": "An error occurred while deleting the schedule. Please try again.",
+    "empty": "No actions registered."
+  },
+  "schedule": {
+    "editTitle": "Edit schedule",
+    "createTitle": "New schedule",
+    "editDescription": "Change the selected schedule.",
+    "createDescription": "A title and dates are enough to add it.",
+    "basics": "Basics",
+    "title": "Title",
+    "titlePlaceholder": "What do you want to do?",
+    "description": "Description",
+    "descriptionPlaceholder": "Notes or details",
+    "location": "Location",
+    "locationPlaceholder": "Location (optional)",
+    "dateTime": "Date and time",
+    "allDay": "All day",
+    "allDayHint": "Turn off to set start and end times",
+    "startDate": "Start date",
+    "endDate": "End date",
+    "startTime": "Start time",
+    "endTime": "End time",
+    "pickDate": "Pick a date",
+    "options": "Options",
+    "priority": "Priority",
+    "color": "Color",
+    "colorAria": "Color {color}",
+    "customColor": "Custom",
+    "customColorAria": "Custom color",
+    "recurrence": "Repeat",
+    "recurrencePlaceholder": "Repeat interval",
+    "recurrenceHint": "Repeating schedules expand automatically on the calendar.",
+    "interval": "Interval",
+    "everyWeeks": "weeks",
+    "everyDays": "days",
+    "weekdays": "Days",
+    "recurrenceEnd": "Ends",
+    "endConditionPlaceholder": "End condition",
+    "endNever": "Never",
+    "endUntil": "On date",
+    "endCount": "After occurrences",
+    "untilDate": "End date",
+    "count": "Occurrences",
+    "countSuffix": "times",
+    "customRrule": "Custom RRULE",
+    "invalidRange": "End date/time cannot be before start.",
+    "invalidRule": "Could not build the recurrence rule.",
+    "saveFailed": "Failed to save schedule: {error}",
+    "deleteFailed": "Failed to delete schedule: {error}",
+    "loadFailed": "Failed to load schedules: {error}"
+  },
+  "recurrence": {
+    "none": "Does not repeat",
+    "daily": "Daily",
+    "weekdays": "Weekdays (Mon–Fri)",
+    "weekly": "Weekly",
+    "monthly": "Monthly",
+    "everyNDays": "Every N days",
+    "everyNWeeks": "Every N weeks",
+    "custom": "Custom",
+    "weekday": {
+      "MO": "Mon",
+      "TU": "Tue",
+      "WE": "Wed",
+      "TH": "Thu",
+      "FR": "Fri",
+      "SA": "Sat",
+      "SU": "Sun"
+    }
+  },
+  "help": {
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "welcome": {
+      "title": "Welcome!",
+      "description": "Welcome to Croffle.",
+      "content": "Use the left menu to switch between today's tasks\nand the full calendar."
+    },
+    "addTodo": {
+      "title": "Add a task",
+      "description": "Create a schedule with one click.",
+      "content": "Click a date on the calendar to jot down a task.\nYou can also drag to move dates!"
+    },
+    "theme": {
+      "title": "Set your theme",
+      "description": "Pick colors that suit you.",
+      "content": "Change Croffle's main color in Settings\nto make the workspace yours."
+    },
+    "ready": {
+      "title": "You're ready!",
+      "description": "That's everything you need.",
+      "content": "Add your first task and plan the day with Croffle!"
+    }
+  },
+  "update": {
+    "available": "A new version is available.",
+    "availableDescription": "You can update to version {version}.",
+    "downloading": "Downloading... ({percent}%)",
+    "skip": "Skip this version",
+    "later": "Apply on next launch",
+    "now": "Update now",
+    "alreadyLatest": "You're already on the latest version.",
+    "failed": "Update failed",
+    "errorFallback": "An error occurred during the update."
+  },
+  "extensions": {
+    "loadFailed": "Failed to load extensions",
+    "loadOneFailed": "Failed to load extension {id}",
+    "executeFailed": "Failed to execute extension {name}",
+    "unloadFailed": "Failed to unload extension {id}"
+  }
+}

--- a/apps/desktop/src/renderer/src/i18n/locales/ko.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ko.json
@@ -1,0 +1,253 @@
+{
+  "common": {
+    "save": "저장",
+    "cancel": "취소",
+    "close": "닫기",
+    "delete": "삭제",
+    "retry": "다시 시도",
+    "add": "추가"
+  },
+  "language": {
+    "ko": "한국어",
+    "en": "English"
+  },
+  "priority": {
+    "low": "낮음",
+    "medium": "보통",
+    "high": "높음"
+  },
+  "settings": {
+    "title": "설정",
+    "description": "설정을 관리하고 업데이트하세요.",
+    "tabs": {
+      "general": "일반",
+      "calendar": "캘린더",
+      "notifications": "알림",
+      "extensions": "확장 관리"
+    },
+    "loading": "설정을 불러오는 중...",
+    "loadFailed": "설정을 불러오지 못했습니다.",
+    "general": {
+      "intro": "앱 전역 기본 설정입니다.",
+      "display": "표시",
+      "language": "언어",
+      "languagePlaceholder": "언어 선택",
+      "theme": "테마",
+      "themePlaceholder": "테마 선택",
+      "themeLight": "라이트",
+      "themeDark": "다크",
+      "themeSystem": "시스템 설정 따름",
+      "updates": "업데이트",
+      "autoUpdate": "자동 업데이트",
+      "autoUpdateHint": "새 버전이 있으면 자동으로 확인하고 알립니다.",
+      "startup": "시작 프로그램",
+      "startOnBoot": "OS 시작 시 실행",
+      "startOnBootHint": "켜면 로그인 시 Croffle이 자동으로 실행됩니다.",
+      "startupBehavior": "시작 시 동작",
+      "startupBehaviorPlaceholder": "시작 동작 선택",
+      "startupOpenLast": "마지막에 열었던 화면",
+      "startupOpenCalendar": "캘린더 기본 화면",
+      "startupDoNothing": "열지 않음 (백그라운드)",
+      "startupBehaviorHint": "OS 시작으로 앱이 실행될 때의 초기 화면 동작입니다.",
+      "startMinimized": "최소화로 시작",
+      "startMinimizedHint": "시작 시 창을 표시하지 않고 트레이에서 실행합니다."
+    },
+    "calendar": {
+      "intro": "캘린더 표시 방식을 설정합니다.",
+      "defaultView": "기본 뷰",
+      "defaultViewPlaceholder": "기본 뷰 선택",
+      "viewDay": "일",
+      "viewWeek": "주",
+      "viewMonth": "월",
+      "viewYear": "연",
+      "weekStart": "한 주의 시작 요일",
+      "weekStartPlaceholder": "시작 요일",
+      "weekStartSunday": "일요일",
+      "weekStartMonday": "월요일",
+      "timeFormat": "시간 형식",
+      "timeFormatPlaceholder": "시간 형식",
+      "timeFormat12h": "12시간 (AM/PM)",
+      "timeFormat24h": "24시간",
+      "showWeekNumbers": "주차 표시",
+      "showWeekNumbersHint": "캘린더에 주차 번호를 표시합니다."
+    },
+    "notifications": {
+      "intro": "일정 알림 설정입니다.",
+      "enabled": "알림 사용",
+      "enabledHint": "일정 알림을 받을지 설정합니다.",
+      "defaultTime": "기본 알림 시간",
+      "defaultTimePlaceholder": "알림 시점",
+      "minutesBefore": "{minutes}분 전",
+      "defaultTimeHint": "새 일정 생성 시 기본으로 적용되는 알림 시점입니다.",
+      "comingSoon": "아래 항목은 추후 계정/알림 고도화용 UI입니다 (현재 AppSettings에 미포함).",
+      "emailAlert": "이메일 알림 (준비 중)",
+      "dnd": "방해 금지 (준비 중)"
+    },
+    "extensions": {
+      "intro": "확장을 설치하고 관리합니다.",
+      "installFromGithub": "GitHub에서 설치",
+      "install": "설치",
+      "installFromZip": "로컬 Zip 파일로 설치",
+      "selectAndInstall": "파일 선택 및 설치",
+      "installed": "설치된 확장",
+      "emptyTitle": "설치된 확장이 없습니다.",
+      "emptyHint": "위쪽 설치 폼에 GitHub URL을 입력하여 확장을 추가해보세요.",
+      "enabled": "사용 중",
+      "disabled": "사용 안 함",
+      "enableAria": "확장 활성화",
+      "uninstallConfirm": "'{name}' 확장을 삭제하시겠습니까?",
+      "configHeading": "{name} 확장 구성"
+    },
+    "errors": {
+      "uiDraftLoad": "UI draft 로드 실패: {error}",
+      "uiDraftSave": "UI draft 저장 실패: {error}",
+      "load": "설정 로드 실패: {error}",
+      "extensionsList": "확장 목록 로드 실패: {error}",
+      "install": "Failed to install extension: {error}",
+      "installLocal": "Failed to install local extension: {error}",
+      "toggle": "확장 토글 실패: {error}",
+      "uninstall": "확장 삭제 실패: {error}",
+      "save": "설정 저장 실패: {error}"
+    }
+  },
+  "sidebar": {
+    "tagline": "할일 달력",
+    "mainMenu": "메인 메뉴",
+    "notifications": "알림",
+    "settings": "설정",
+    "help": "도움말",
+    "calendar": {
+      "title": "캘린더",
+      "subtitle": "Calendar"
+    }
+  },
+  "rightSidebar": {
+    "title": "일정 관리",
+    "subtitle": "오늘의 일정과 계획",
+    "add": "새 일정 추가",
+    "today": "오늘의 일정",
+    "emptyToday": "오늘 일정이 없습니다",
+    "upcoming": "다가오는 일정",
+    "emptyUpcoming": "다가오는 일정이 없습니다"
+  },
+  "contextMenu": {
+    "addSchedule": "일정 추가",
+    "viewDay": "해당 일자 보기",
+    "editSchedule": "일정 수정",
+    "deleteSchedule": "일정 삭제",
+    "deleteConfirm": "이 일정을 삭제하시겠습니까?",
+    "deleteFailed": "일정 삭제에 실패했습니다. 다시 시도해주세요.",
+    "deleteSuccess": "일정이 삭제되었습니다.",
+    "deleteError": "일정 삭제 중 오류가 발생했습니다. 다시 시도해주세요.",
+    "empty": "등록된 동작이 없습니다."
+  },
+  "schedule": {
+    "editTitle": "일정 수정",
+    "createTitle": "새 일정",
+    "editDescription": "선택한 일정의 내용을 변경합니다.",
+    "createDescription": "제목과 날짜만 있어도 바로 추가할 수 있어요.",
+    "basics": "기본 정보",
+    "title": "제목",
+    "titlePlaceholder": "무엇을 할까요?",
+    "description": "설명",
+    "descriptionPlaceholder": "메모나 세부 내용을 남겨두세요",
+    "location": "장소",
+    "locationPlaceholder": "장소 (선택)",
+    "dateTime": "날짜와 시간",
+    "allDay": "하루 종일",
+    "allDayHint": "끄면 시작·종료 시간을 설정할 수 있어요",
+    "startDate": "시작일",
+    "endDate": "종료일",
+    "startTime": "시작 시간",
+    "endTime": "종료 시간",
+    "pickDate": "날짜 선택",
+    "options": "옵션",
+    "priority": "우선순위",
+    "color": "색상",
+    "colorAria": "색상 {color}",
+    "customColor": "직접 선택",
+    "customColorAria": "사용자 지정 색상",
+    "recurrence": "반복",
+    "recurrencePlaceholder": "반복 주기",
+    "recurrenceHint": "캘린더에는 반복 일정이 자동으로 펼쳐져 표시됩니다.",
+    "interval": "간격",
+    "everyWeeks": "주마다",
+    "everyDays": "일마다",
+    "weekdays": "요일",
+    "recurrenceEnd": "반복 종료",
+    "endConditionPlaceholder": "종료 조건",
+    "endNever": "종료 없음",
+    "endUntil": "날짜까지",
+    "endCount": "횟수",
+    "untilDate": "종료일",
+    "count": "횟수",
+    "countSuffix": "회 반복",
+    "customRrule": "사용자 지정 RRULE",
+    "invalidRange": "종료 일시는 시작 일시보다 빠를 수 없습니다.",
+    "invalidRule": "반복 규칙을 만들 수 없습니다.",
+    "saveFailed": "일정 저장 실패: {error}",
+    "deleteFailed": "일정 삭제 실패: {error}",
+    "loadFailed": "일정 불러오기 실패: {error}"
+  },
+  "recurrence": {
+    "none": "반복 안 함",
+    "daily": "매일",
+    "weekdays": "평일 (월–금)",
+    "weekly": "매주",
+    "monthly": "매월",
+    "everyNDays": "N일마다",
+    "everyNWeeks": "N주마다",
+    "custom": "사용자 지정",
+    "weekday": {
+      "MO": "월",
+      "TU": "화",
+      "WE": "수",
+      "TH": "목",
+      "FR": "금",
+      "SA": "토",
+      "SU": "일"
+    }
+  },
+  "help": {
+    "prev": "이전",
+    "next": "다음",
+    "done": "확인",
+    "welcome": {
+      "title": "환영합니다!",
+      "description": "크로플(CROFFLE)에 오신 것을 환영해요.",
+      "content": "왼쪽 메뉴를 통해 오늘 할 일과\n전체 달력을 자유롭게 오갈 수 있습니다."
+    },
+    "addTodo": {
+      "title": "할 일 추가하기",
+      "description": "클릭 한 번으로 일정을 등록하세요.",
+      "content": "달력의 날짜를 클릭하면 즉시 할 일을 적을 수 있습니다.\n드래그해서 날짜를 옮기는 것도 가능해요!"
+    },
+    "theme": {
+      "title": "나만의 테마 설정",
+      "description": "취향에 맞는 색상으로 꾸며보세요.",
+      "content": "설정 메뉴에서 크로플의 메인 색상을 변경하여\n본인만의 작업 환경을 만들 수 있습니다."
+    },
+    "ready": {
+      "title": "준비 완료!",
+      "description": "이제 모든 준비가 끝났습니다.",
+      "content": "지금 바로 첫 번째 할 일을 등록하고\n크로플과 함께 멋진 하루를 계획해 보세요!"
+    }
+  },
+  "update": {
+    "available": "새 버전이 있습니다.",
+    "availableDescription": "v{version} 버전으로 업데이트 할 수 있습니다.",
+    "downloading": "다운로드 중... ({percent}%)",
+    "skip": "이번 버전은 건너뛰기",
+    "later": "다음 시작 시 적용",
+    "now": "지금 업데이트",
+    "alreadyLatest": "이미 최신 버전입니다.",
+    "failed": "업데이트 실패",
+    "errorFallback": "업데이트 중 오류가 발생했습니다."
+  },
+  "extensions": {
+    "loadFailed": "Failed to load extensions",
+    "loadOneFailed": "Failed to load extension {id}",
+    "executeFailed": "Failed to execute extension {name}",
+    "unloadFailed": "Failed to unload extension {id}"
+  }
+}

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -6,6 +6,7 @@ import { createPinia } from 'pinia';
 import { createApp } from 'vue';
 
 import App from './app.vue';
+import { i18n } from './i18n';
 import router from './router';
 // import { initTestPlugin } from './test/testPluginMenu';
 
@@ -14,6 +15,7 @@ const pinia = createPinia();
 
 app.use(pinia);
 app.use(router);
+app.use(i18n);
 // initTestPlugin();
 
 app.mount('#app');

--- a/apps/desktop/src/renderer/src/services/extension-loader.ts
+++ b/apps/desktop/src/renderer/src/services/extension-loader.ts
@@ -2,6 +2,12 @@ import type { ExtensionInfo } from '@croffledev/common';
 import type { ExtensionContext, RegisterConfigurationTabOptions } from '@croffledev/croffle-types';
 import { toast } from 'vue-sonner';
 
+import { i18n } from '@/i18n';
+
+function t(key: string, values?: Record<string, unknown>) {
+  return String(values ? i18n.global.t(key, values) : i18n.global.t(key));
+}
+
 class ExtensionLoader {
   private activeExtensions = new Map<string, unknown>();
 
@@ -12,7 +18,7 @@ class ExtensionLoader {
         await this.loadExtension(extension);
       }
     } catch {
-      toast.error('Failed to load extensions');
+      toast.error(t('extensions.loadFailed'));
     }
   }
 
@@ -24,7 +30,7 @@ class ExtensionLoader {
         await this.loadExtension(extension);
       }
     } catch {
-      toast.error(`Failed to load extension ${extensionId}`);
+      toast.error(t('extensions.loadOneFailed', { id: extensionId }));
     }
   }
 
@@ -67,7 +73,7 @@ class ExtensionLoader {
         }),
       );
     } catch {
-      toast.error(`Failed to execute extension ${extension.name}`);
+      toast.error(t('extensions.executeFailed', { name: extension.name }));
     }
   }
 
@@ -92,7 +98,7 @@ class ExtensionLoader {
         );
       }
     } catch {
-      toast.error(`Failed to unload extension ${extensionId}`);
+      toast.error(t('extensions.unloadFailed', { id: extensionId }));
     }
   }
 

--- a/apps/desktop/src/renderer/src/stores/app-settings-store.ts
+++ b/apps/desktop/src/renderer/src/stores/app-settings-store.ts
@@ -3,11 +3,14 @@ import type { AppSettings } from '@croffledev/croffle-types';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
+import { setI18nLocale } from '@/i18n';
+
 import { useThemeStore } from './theme-store';
 
 const applyToUi = (value: AppSettings) => {
   const themeStore = useThemeStore();
   themeStore.applyFromSettings(value.general.theme);
+  setI18nLocale(value.general.language);
 };
 
 export const useAppSettingsStore = defineStore('appSettings', () => {

--- a/apps/desktop/src/renderer/src/stores/schedule-store.ts
+++ b/apps/desktop/src/renderer/src/stores/schedule-store.ts
@@ -6,6 +6,8 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { toast } from 'vue-sonner';
 
+import { i18n } from '@/i18n';
+
 function toEventDuration(schedule: Schedule): EventInput['duration'] {
   const start = dayjs(schedule.startDate);
   const end = dayjs(schedule.endDate);
@@ -110,7 +112,7 @@ export const useScheduleStore = defineStore('schedule', () => {
       const result = await croffle.calendar.schedules.getAll({ start, end });
       schedules.value = result;
     } catch (error) {
-      toast.error(`일정 불러오기 실패: ${JSON.stringify(error)}`);
+      toast.error(String(i18n.global.t('schedule.loadFailed', { error: JSON.stringify(error) })));
     }
   };
 

--- a/apps/desktop/src/renderer/src/stores/ui-store.ts
+++ b/apps/desktop/src/renderer/src/stores/ui-store.ts
@@ -2,6 +2,14 @@ import dayjs from 'dayjs';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
+export type ConfirmDialogOptions = {
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmVariant?: 'default' | 'destructive';
+};
+
 export const useUiStore = defineStore('ui', () => {
   const leftSidebarOpen = ref(true);
   const rightSidebarOpen = ref(false);
@@ -9,6 +17,14 @@ export const useUiStore = defineStore('ui', () => {
   const isScheduleModalOpen = ref(false);
   const scheduleModalMode = ref<'add' | 'edit'>('add');
   const selectedScheduleId = ref<string | null>(null);
+
+  const isConfirmModalOpen = ref(false);
+  const confirmTitle = ref('');
+  const confirmDescription = ref('');
+  const confirmConfirmLabel = ref('');
+  const confirmCancelLabel = ref('');
+  const confirmVariant = ref<'default' | 'destructive'>('default');
+  let confirmResolver: ((value: boolean) => void) | null = null;
 
   // 사이드바 토글 액션
   const toggleLeftSidebar = () => {
@@ -39,16 +55,53 @@ export const useUiStore = defineStore('ui', () => {
     selectedScheduleId.value = null;
   };
 
+  const resolveConfirm = (value: boolean) => {
+    if (!confirmResolver) {
+      isConfirmModalOpen.value = false;
+      return;
+    }
+    const resolve = confirmResolver;
+    confirmResolver = null;
+    isConfirmModalOpen.value = false;
+    resolve(value);
+  };
+
+  const openConfirm = (options: ConfirmDialogOptions): Promise<boolean> => {
+    if (confirmResolver) {
+      confirmResolver(false);
+      confirmResolver = null;
+    }
+
+    confirmTitle.value = options.title;
+    confirmDescription.value = options.description;
+    confirmConfirmLabel.value = options.confirmLabel ?? '';
+    confirmCancelLabel.value = options.cancelLabel ?? '';
+    confirmVariant.value = options.confirmVariant ?? 'default';
+    isConfirmModalOpen.value = true;
+
+    return new Promise<boolean>((resolve) => {
+      confirmResolver = resolve;
+    });
+  };
+
   return {
     leftSidebarOpen,
     rightSidebarOpen,
     selectedDate,
     isScheduleModalOpen,
+    isConfirmModalOpen,
+    confirmTitle,
+    confirmDescription,
+    confirmConfirmLabel,
+    confirmCancelLabel,
+    confirmVariant,
     toggleLeftSidebar,
     toggleRightSidebar,
     openRightSidebarWithDate,
     openScheduleModal,
     closeScheduleModal,
+    openConfirm,
+    resolveConfirm,
     scheduleModalMode,
     selectedScheduleId,
   };

--- a/apps/desktop/src/renderer/src/stores/update-store.ts
+++ b/apps/desktop/src/renderer/src/stores/update-store.ts
@@ -3,7 +3,12 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { toast } from 'vue-sonner';
 
+import { i18n } from '@/i18n';
 import type { UpdateInfo } from '@/types/update';
+
+function t(key: string) {
+  return String(i18n.global.t(key));
+}
 
 export const useUpdateStore = defineStore('update', () => {
   const isModalOpen = ref<boolean>(false);
@@ -21,7 +26,7 @@ export const useUpdateStore = defineStore('update', () => {
         isModalOpen.value = true;
       }),
       croffle.event.on(AppEventType.UPDATE_NOT_AVAILABLE, () => {
-        toast('이미 최신 버전입니다.');
+        toast(t('update.alreadyLatest'));
       }),
       croffle.event.on(AppEventType.UPDATE_DOWNLOAD_PROGRESS, (payload) => {
         isDownloading.value = true;
@@ -34,12 +39,12 @@ export const useUpdateStore = defineStore('update', () => {
       }),
       croffle.event.on(AppEventType.UPDATE_ERROR, (payload) => {
         const err = payload as Error;
-        const message = err?.message ?? '업데이트 중 오류가 발생했습니다.';
+        const message = err?.message ?? t('update.errorFallback');
         isDownloading.value = false;
         downloadProgress.value = 0;
         isModalOpen.value = false;
         updateError.value = message;
-        toast.error('업데이트 실패', { description: message });
+        toast.error(t('update.failed'), { description: message });
       }),
     ];
   }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.17.0"
+  "packageManager": "pnpm@11.21.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "commander": "^13.1.0",
     "fs-extra": "^11.3.0",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: 6.0.1
+  brace-expansion: 5.0.9
+  fast-uri: 4.1.2
+  undici: 8.10.0
+  js-yaml: 5.3.0
+
 importers:
 
   .:
@@ -55,10 +62,10 @@ importers:
     dependencies:
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@43.2.0(supports-color@7.2.0))
+        version: 3.0.2(electron@43.4.0(supports-color@7.2.0))
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@43.2.0(supports-color@7.2.0))
+        version: 4.0.0(electron@43.4.0(supports-color@7.2.0))
       '@fullcalendar/core':
         specifier: ^6.1.21
         version: 6.1.21
@@ -145,7 +152,7 @@ importers:
         version: 3.5.40(typescript@6.0.3)
       vue-router:
         specifier: ^5.2.0
-        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       vue-sonner:
         specifier: ^2.0.9
         version: 2.0.9
@@ -164,7 +171,7 @@ importers:
         version: 5.0.1(vue@3.5.40(typescript@6.0.3))
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.3.3(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -176,13 +183,13 @@ importers:
         version: 2.1.8
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vue/tsconfig':
         specifier: ^0.9.1
         version: 0.9.1(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
       autoprefixer:
         specifier: ^10.5.4
-        version: 10.5.4(postcss@8.5.25)
+        version: 10.5.4(postcss@8.5.26)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -190,20 +197,20 @@ importers:
         specifier: ^0.31.10
         version: 0.31.10
       electron:
-        specifier: ^43.2.0
-        version: 43.2.0(supports-color@7.2.0)
+        specifier: ^43.4.0
+        version: 43.4.0(supports-color@7.2.0)
       electron-builder:
         specifier: 26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(supports-color@7.2.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(supports-color@7.2.0)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       esbuild:
-        specifier: ^0.28.1
-        version: 0.28.1
+        specifier: ^0.28.2
+        version: 0.28.2
       postcss:
-        specifier: ^8.5.25
-        version: 8.5.25
+        specifier: ^8.5.26
+        version: 8.5.26
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -211,8 +218,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.2.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.9
         version: 3.3.9(typescript@6.0.3)
@@ -220,8 +227,8 @@ importers:
   packages/cli:
     dependencies:
       adm-zip:
-        specifier: ^0.5.16
-        version: 0.5.18
+        specifier: ^0.6.0
+        version: 0.6.0
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -249,7 +256,7 @@ importers:
         version: 2.4.9
       tsup:
         specifier: ^8.3.6
-        version: 8.5.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(jiti@2.7.0)(postcss@8.5.25)(supports-color@7.2.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -528,8 +535,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -552,8 +559,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -576,8 +583,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -600,8 +607,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -624,8 +631,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -648,8 +655,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -672,8 +679,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -696,8 +703,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -720,8 +727,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -744,8 +751,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -768,8 +775,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -792,8 +799,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -816,8 +823,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -840,8 +847,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -864,8 +871,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -888,8 +895,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -912,8 +919,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -930,8 +937,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -954,8 +961,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -972,8 +979,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -996,8 +1003,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -1014,8 +1021,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1038,8 +1045,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1062,8 +1069,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1086,8 +1093,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -1110,8 +1117,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2184,6 +2191,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
@@ -2260,6 +2272,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -2280,9 +2293,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.18:
-    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2318,9 +2331,6 @@ packages:
     peerDependencies:
       dmg-builder: 26.15.3
       electron-builder-squirrel-windows: 26.15.3
-
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2369,9 +2379,6 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2405,14 +2412,8 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2538,9 +2539,6 @@ packages:
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2794,8 +2792,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.2.0:
-    resolution: {integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==}
+  electron@43.4.0:
+    resolution: {integrity: sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -2862,8 +2860,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2935,11 +2933,6 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -2984,8 +2977,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3270,16 +3263,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
-    hasBin: true
-
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3630,9 +3615,9 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -3862,8 +3847,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.25:
-    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -4166,9 +4151,6 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -4366,13 +4348,9 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
-    engines: {node: '>=18.17'}
-
-  undici@7.29.0:
-    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
-    engines: {node: '>=20.18.1'}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -4437,8 +4415,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite@8.2.0:
-    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4858,7 +4836,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 5.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -4917,17 +4895,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron-toolkit/preload@3.0.2(electron@43.2.0(supports-color@7.2.0))':
+  '@electron-toolkit/preload@3.0.2(electron@43.4.0(supports-color@7.2.0))':
     dependencies:
-      electron: 43.2.0(supports-color@7.2.0)
+      electron: 43.4.0(supports-color@7.2.0)
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@26.1.2)':
     dependencies:
       '@types/node': 26.1.2
 
-  '@electron-toolkit/utils@4.0.0(electron@43.2.0(supports-color@7.2.0))':
+  '@electron-toolkit/utils@4.0.0(electron@43.4.0(supports-color@7.2.0))':
     dependencies:
-      electron: 43.2.0(supports-color@7.2.0)
+      electron: 43.4.0(supports-color@7.2.0)
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -4964,7 +4942,7 @@ snapshots:
       semver: 7.8.5
       sumchecker: 3.0.1(supports-color@7.2.0)
     optionalDependencies:
-      undici: 7.29.0
+      undici: 8.10.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5055,7 +5033,7 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
@@ -5067,7 +5045,7 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -5079,7 +5057,7 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
   '@esbuild/android-x64@0.18.20':
@@ -5091,7 +5069,7 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -5103,7 +5081,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
@@ -5115,7 +5093,7 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -5127,7 +5105,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
@@ -5139,7 +5117,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -5151,7 +5129,7 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
@@ -5163,7 +5141,7 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -5175,7 +5153,7 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
@@ -5187,7 +5165,7 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -5199,7 +5177,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
@@ -5211,7 +5189,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -5223,7 +5201,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
   '@esbuild/linux-s390x@0.18.20':
@@ -5235,7 +5213,7 @@ snapshots:
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -5247,7 +5225,7 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
@@ -5256,7 +5234,7 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.18.20':
@@ -5268,7 +5246,7 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
@@ -5277,7 +5255,7 @@ snapshots:
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -5289,7 +5267,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
@@ -5298,7 +5276,7 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.18.20':
@@ -5310,7 +5288,7 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -5322,7 +5300,7 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.18.20':
@@ -5334,7 +5312,7 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
@@ -5346,7 +5324,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.10.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))':
@@ -5961,12 +5939,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@tanstack/table-core@8.21.3': {}
 
@@ -6163,10 +6141,10 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.40(typescript@6.0.3)
 
   '@volar/language-core@2.4.28':
@@ -6175,11 +6153,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@vue-macros/common@3.1.4(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -6213,7 +6193,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.25
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -6298,7 +6278,7 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  adm-zip@0.5.18: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 
@@ -6312,7 +6292,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6359,7 +6339,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -6375,10 +6355,6 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -6413,18 +6389,16 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  autoprefixer@10.5.4(postcss@8.5.25):
+  autoprefixer@10.5.4(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.7
       caniuse-lite: 1.0.30001806
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.25
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   aws4@1.13.2: {}
-
-  balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -6449,16 +6423,7 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6493,7 +6458,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -6590,8 +6555,6 @@ snapshots:
 
   compare-version@0.1.2: {}
 
-  concat-map@0.0.1: {}
-
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
@@ -6679,7 +6642,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -6763,7 +6726,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -6772,7 +6735,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(supports-color@7.2.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  electron-vite@5.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(supports-color@7.2.0)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
@@ -6780,7 +6743,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     optionalDependencies:
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
     transitivePeerDependencies:
@@ -6798,7 +6761,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.2.0(supports-color@7.2.0):
+  electron@43.4.0(supports-color@7.2.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@7.2.0)
@@ -6931,34 +6894,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
-  esbuild@0.28.1:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -7044,8 +7007,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
-  esprima@4.0.1: {}
-
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -7082,7 +7043,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@4.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -7380,16 +7341,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.3.1:
+  js-yaml@5.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -7626,19 +7578,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -7671,7 +7623,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@6.0.1: {}
 
   natural-compare@1.4.0: {}
 
@@ -7695,7 +7647,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.21
       tinyglobby: 0.2.17
-      undici: 6.27.0
+      undici: 8.10.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -7881,12 +7833,12 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.25
+      postcss: 8.5.26
       tsx: 4.23.1
       yaml: 2.9.0
 
@@ -7897,9 +7849,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.25:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 6.0.1
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7974,7 +7926,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 5.3.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -8170,8 +8122,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  sprintf-js@1.0.3: {}
-
   sprintf-js@1.1.3:
     optional: true
 
@@ -8303,7 +8253,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(jiti@2.7.0)(postcss@8.5.25)(supports-color@7.2.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -8314,7 +8264,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.1)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.62.2
       source-map: 0.7.6
@@ -8324,7 +8274,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
-      postcss: 8.5.25
+      postcss: 8.5.26
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -8334,7 +8284,7 @@ snapshots:
 
   tsx@4.23.1:
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -8370,10 +8320,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@6.27.0: {}
-
-  undici@7.29.0:
-    optional: true
+  undici@8.10.0: {}
 
   universalify@0.1.2: {}
 
@@ -8384,16 +8331,16 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       rolldown: 1.2.1
       rollup: 4.62.2
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   unzipper@0.12.5:
     dependencies:
@@ -8417,16 +8364,16 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.25
+      postcss: 8.5.26
       rolldown: 1.2.1
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.2
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.1
@@ -8450,7 +8397,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.4(vue@3.5.40(typescript@6.0.3))
@@ -8467,14 +8414,14 @@ snapshots:
       picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       unplugin-utils: 0.3.2
       vue: 3.5.40(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
       pinia: 4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -8489,7 +8436,7 @@ snapshots:
 
   vue-tsc@3.3.9(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
       '@vue/language-core': 3.3.9
       typescript: 6.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nanoid: 6.0.1
-  brace-expansion: 5.0.9
-  fast-uri: 4.1.2
-  undici: 8.10.0
-  js-yaml: 5.3.0
+  nanoid@^3: 3.3.18
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^2: 2.1.4
+  brace-expansion@^5: 5.0.9
+  fast-uri@^3: 3.1.5
+  undici@^6: 6.28.0
+  js-yaml@^3: 3.15.1
+  js-yaml@^4: 4.3.1
 
 importers:
 
@@ -2354,6 +2357,9 @@ packages:
       dmg-builder: 26.15.3
       electron-builder-squirrel-windows: 26.15.3
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2401,6 +2407,9 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2433,6 +2442,12 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -2561,6 +2576,9 @@ packages:
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2955,6 +2973,11 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -2999,8 +3022,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3285,8 +3308,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.3.0:
-    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3637,9 +3664,9 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@6.0.1:
-    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
-    engines: {node: ^22 || ^24 || >=26}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -4173,6 +4200,9 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -4370,9 +4400,13 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -4864,7 +4898,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -4970,7 +5004,7 @@ snapshots:
       semver: 7.8.5
       sumchecker: 3.0.1(supports-color@7.2.0)
     optionalDependencies:
-      undici: 8.10.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6340,7 +6374,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6387,7 +6421,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -6403,6 +6437,10 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -6448,6 +6486,8 @@ snapshots:
 
   aws4@1.13.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -6470,6 +6510,15 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -6506,7 +6555,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -6603,6 +6652,8 @@ snapshots:
 
   compare-version@0.1.2: {}
 
+  concat-map@0.0.1: {}
+
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
@@ -6690,7 +6741,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -6774,7 +6825,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -7055,6 +7106,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -7091,7 +7144,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -7389,7 +7442,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.3.0:
+  js-yaml@3.15.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7630,15 +7688,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -7671,7 +7729,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@6.0.1: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -7695,7 +7753,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.21
       tinyglobby: 0.2.17
-      undici: 8.10.0
+      undici: 6.28.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -7899,7 +7957,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 6.0.1
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7974,7 +8032,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 5.3.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -8169,6 +8227,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3:
     optional: true
@@ -8368,7 +8428,10 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.10.0: {}
+  undici@6.28.0: {}
+
+  undici@7.29.0:
+    optional: true
 
   universalify@0.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
+      vue-i18n:
+        specifier: ^11.4.8
+        version: 11.4.8(vue@3.5.40(typescript@6.0.3))
       vue-router:
         specifier: ^5.2.0
         version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
@@ -1265,6 +1268,22 @@ packages:
   '@internationalized/number@3.6.7':
     resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
 
+  '@intlify/core-base@11.4.8':
+    resolution: {integrity: sha512-A+Q7SKm5oEcy1E/cghqd7n/St4XjTqLhiiyDuieNcMrJcrHlkY5n0jp7Q9dD3txvVHzvsmBVV5M9wD5/s1zfzw==}
+    engines: {node: '>= 22'}
+
+  '@intlify/devtools-types@11.4.8':
+    resolution: {integrity: sha512-MGpID+rlfzGUbNcnC20bm5NMSBHPrvx0atLTfv9dftn3kjXw1hGKDcIcwrO99tSrZEc2i+hczRL7ks8qXsHPkQ==}
+    engines: {node: '>= 22'}
+
+  '@intlify/message-compiler@11.4.8':
+    resolution: {integrity: sha512-vbzk17dYwduYiv52EK61+FDCyhfVg1uPUtPmiD/d45W99uJIcXywrweOBcHv7n9/iEqmXiMGT52bgJbZDQqK3w==}
+    engines: {node: '>= 22'}
+
+  '@intlify/shared@11.4.8':
+    resolution: {integrity: sha512-XbRgrv+XEuvDr7UCY55oibVrh+o4u+A0VB6nSL0F5Z8LcZxE/8j573LYG6bCrOigIcHdGpSNI7Rh5UpC5/B/eg==}
+    engines: {node: '>= 22'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -2217,6 +2236,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.40':
     resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/devtools-api@8.2.1':
     resolution: {integrity: sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==}
@@ -4478,6 +4500,12 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
+  vue-i18n@11.4.8:
+    resolution: {integrity: sha512-0ULeHP6Z9CGvAm67S77ZEp41cfGXIREGL8qfhos2BMgcQQewtQcDKuojt6jjasAD/S8GwfTp2ySPmDSpwvrCMQ==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-router@5.2.0:
     resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
     peerDependencies:
@@ -5466,6 +5494,24 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
 
+  '@intlify/core-base@11.4.8':
+    dependencies:
+      '@intlify/devtools-types': 11.4.8
+      '@intlify/message-compiler': 11.4.8
+      '@intlify/shared': 11.4.8
+
+  '@intlify/devtools-types@11.4.8':
+    dependencies:
+      '@intlify/core-base': 11.4.8
+      '@intlify/shared': 11.4.8
+
+  '@intlify/message-compiler@11.4.8':
+    dependencies:
+      '@intlify/shared': 11.4.8
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.4.8': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -6200,6 +6246,8 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.40
       '@vue/shared': 3.5.40
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-api@8.2.1':
     dependencies:
@@ -8396,6 +8444,14 @@ snapshots:
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
+
+  vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)):
+    dependencies:
+      '@intlify/core-base': 11.4.8
+      '@intlify/devtools-types': 11.4.8
+      '@intlify/shared': 11.4.8
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.40(typescript@6.0.3)
 
   vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.1)(rollup@4.62.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,11 @@ packages:
   - 'packages/*'
 
 overrides:
-  nanoid: 6.0.1
-  brace-expansion: 5.0.9
-  fast-uri: 4.1.2
-  undici: 8.10.0
-  js-yaml: 5.3.0
+  nanoid@^3: 3.3.18
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^2: 2.1.4
+  brace-expansion@^5: 5.0.9
+  fast-uri@^3: 3.1.5
+  undici@^6: 6.28.0
+  js-yaml@^3: 3.15.1
+  js-yaml@^4: 4.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,10 @@ allowBuilds:
 packages:
   - 'apps/*'
   - 'packages/*'
+
+overrides:
+  nanoid: 6.0.1
+  brace-expansion: 5.0.9
+  fast-uri: 4.1.2
+  undici: 8.10.0
+  js-yaml: 5.3.0


### PR DESCRIPTION
## Summary

- Settings `general.language` (`ko` / `en`) now switches renderer UI copy via vue-i18n, instead of only feeding FullCalendar.
- Built-in screens, toasts, menus, and recurrence labels live in `en.json` / `ko.json`. Default locale is `en`.
- FullCalendar weekday/button chrome follows the same setting. Tray labels are English for now (main-process i18n is not wired).

## Package scope

- [x] `apps/desktop`
- [ ] `packages/types`
- [x] `packages/cli`
- [x] Root / workspace / CI

## Electron surface

- [x] Main
- [ ] Preload / host API
- [x] Renderer
- [ ] Native / IPC / packaging

## Related issues

N/A

## Motivation / user story

The language setting existed but almost nothing used it. The UI was hardcoded Korean, the default setting was `en`, and the calendar fallback was `ko`, so switching language did not change the product. Users who pick English (or Korean) should see matching chrome after save.

## Approach

- Add vue-i18n (Composition API, `legacy: false`) in the renderer only. Catalogs: `apps/desktop/src/renderer/src/i18n/locales/{en,ko}.json`.
- Apply `settings.general.language` in `applyToUi` on load and `SETTINGS_UPDATE` so locale switches without remounting.
- Replace user-visible host strings with keys. Recurrence preset/weekday labels left `common` (shared with main) and are translated only in the renderer.
- Built-in menus store i18n keys; extension-provided labels stay raw (`translateOrRaw`) so they are not looked up as keys.
- Import FullCalendar `ko` locale, default calendar locale to `en`, keep `setOption('locale')` on settings changes. dayjs is date-math only and is not localized.
- Tray context menu is English as a fallback until main-process `t()` exists. OS locale detection and extension language packs are out of scope.

## API / contract changes

None for `@croffledev/croffle-types` / CLI / `window.croffle`.

Internal: `RECURRENCE_PRESET_OPTIONS` / `WEEKDAY_OPTIONS` in desktop `common` are value lists only (no Korean `label` field). Desktop-only; not a published package.

## Test plan

- [x] Happy path verified
- [x] `pnpm typecheck` passes for affected packages
- [x] Built and smoke-tested (`pnpm dev` / `pnpm build` as relevant)
- [x] Verified on Windows and Linux 
- [x] Changeset added for publishable packages (`types` / `cli`) when public API changed
- [ ] Docs / README / template samples updated _(if user-facing)_
- Edge cases / failure paths checked
  - Locale swith & sync
    - [x] On startup, UI show correct language before/after settings load (initial `en` → apply from settings)
    - [x] After changing language in Settings and saving, sidebar / modals / toasts / context menus update immediately
    - [x] Changing language then canceling restores previous UI + calendar locale
    - [x] Unknown/corrupt `general.language` falls back to `en`
  - FullCalendar
    - [x] Switching `ko` ↔ `en` actually updates via setOption('locale')
    - [x] When language isn’t ready yet, calendar defaults to en
  - Menus & extensions
    - [x] Built-in menu/context-menu keys render as translated labels
    - [x] Extension labels that don’t match catalog keys stay raw; accidental key collisions get translated
    - [x] Delete confirm / success / failure toasts use the current locale
  - Schedule & recurrence
    - [x] Schedule modal date formatting matches locale (ko-KR / en-US)
  - Settings & other UI surfaces
    - [x] No raw i18n keys visible across settings / schedule / help / update / right-sidebar
    - [x] Extension load / execute / unload failure toasts use current language + id/name substitution
  - Intentional out-of-scope (regression only)
    - [x] System tray stays English (Open Window / Exit App) regardless of app language
    - [x] Main/common recurrence logic still works after labels moved out of shared code
  - Failure & save paths
    - [x] Settings save failure shows i18n error toast and does not leave locale half-applied
    - [x] Delete failure / catch toasts are correct per language


### Manual steps

1. Fresh settings (or `language: en`): Settings, calendar, schedule modal, sidebars, help, update toast/modal, context menus, and recurrence presets are English. FullCalendar weekday/today chrome is English.
2. Set language to Korean, save: the same surfaces switch to Korean without restart. Calendar locale follows.
3. Switch back to English and save: UI and calendar revert.
4. Open an extension view / configuration tab / context menu: host chrome is translated; extension-provided labels stay as the extension passed them.
5. Right-click tray: labels are English regardless of the language setting (expected until main i18n).

## Screenshots / demo

<img width="1502" height="802" alt="image" src="https://github.com/user-attachments/assets/2e3100af-7b26-4b76-b15b-27a89f6cc8a9" />

<img width="1372" height="562" alt="image" src="https://github.com/user-attachments/assets/5272df3d-5c3d-470e-b9e7-f628a54fabea" />


## Release notes

Notes: Croffle desktop now honors the General → Language setting (`English` / `한국어`) for renderer UI and the calendar. Default language is English. Extensions still supply their own labels; they cannot add host languages yet. The system tray menu is English until main-process i18n lands.

## Additional notes for reviewers

- This branch also includes `chore: update deps` (root / desktop / CLI lockfile). Unrelated to i18n; split if you want a deps-only PR.
- `packages/cli/package.json` changed only via that deps commit. No CLI behavior or public API change from i18n. No changeset unless you treat the dep bump as a publishable CLI change.
- Do not commit `.pnpm-store/` if it reappears locally.